### PR TITLE
Fixes the HTTP header issue with KBase's auth2 server

### DIFF
--- a/auth/kbase_auth_server.go
+++ b/auth/kbase_auth_server.go
@@ -104,11 +104,7 @@ func (server *KBaseAuthServer) newRequest(method, resource string,
 	if err != nil {
 		return nil, err
 	}
-	// The required authorization header contains only the unencoded access token.
-	// Unfortunately, this is a non-RFC-compliant Authorization header, and Go
-	// validates its request headers, so it can't send non-compliant ones. The
-	// following won't work till this is fixed, so we can't rely on the KBase
-	// auth server for now
+	// the required authorization header contains only the unencoded access token
 	req.Header.Add("Authorization", server.AccessToken)
 	return req, nil
 }

--- a/auth/kbase_auth_server.go
+++ b/auth/kbase_auth_server.go
@@ -58,10 +58,10 @@ func NewKBaseAuthServer(accessToken string) (*KBaseAuthServer, error) {
 
 		// verify that the access token works (i.e. that the user is logged in)
 		resp, err := server.get("me")
-		defer resp.Body.Close()
 		if err != nil {
 			return nil, err
 		} else if resp.StatusCode != 200 {
+			defer resp.Body.Close()
 			err = kbaseAuthError(resp)
 		}
 
@@ -109,7 +109,7 @@ func (server *KBaseAuthServer) newRequest(method, resource string,
 	// validates its request headers, so it can't send non-compliant ones. The
 	// following won't work till this is fixed, so we can't rely on the KBase
 	// auth server for now
-	req.Header.Set("Authorization", server.AccessToken)
+	req.Header.Add("Authorization", server.AccessToken)
 	return req, nil
 }
 

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
+	//	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -18,7 +18,7 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/net/netutil"
 
-	//	"dts/auth"
+	"dts/auth"
 	"dts/config"
 	"dts/core"
 	"dts/databases"
@@ -67,22 +67,20 @@ func getAuthInfo(header http.Header) (string, string, error) {
 	// FIXME: KBase Auth server needs to be modified to use an RFC-compliant
 	// FIXME: Authorization header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization)
 	// FIXME: so for now we just use a hard-wired ORCID
-	return accessToken, os.Getenv("DTS_KBASE_TEST_ORCID"), err
+	//	return accessToken, os.Getenv("DTS_KBASE_TEST_ORCID"), err
 
-	/*
-		// check the access token against the KBase auth server
-		// and fetch the first ORCID associated with it
-		authServer, err := auth.NewKBaseAuthServer(accessToken)
-		var orcid string
-		var orcids []string
+	// check the access token against the KBase auth server
+	// and fetch the first ORCID associated with it
+	authServer, err := auth.NewKBaseAuthServer(accessToken)
+	var orcid string
+	var orcids []string
+	if err == nil {
+		orcids, err = authServer.Orcids()
 		if err == nil {
-			orcids, err = authServer.Orcids()
-			if err == nil {
-				orcid = orcids[0]
-			}
+			orcid = orcids[0]
 		}
-		return accessToken, orcid, err
-	*/
+	}
+	return accessToken, orcid, err
 }
 
 // this type encodes a JSON object for responding to root queries

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -62,12 +62,7 @@ func getAuthInfo(header http.Header) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	accessToken := string(accessTokenBytes)
-
-	// FIXME: KBase Auth server needs to be modified to use an RFC-compliant
-	// FIXME: Authorization header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization)
-	// FIXME: so for now we just use a hard-wired ORCID
-	//	return accessToken, os.Getenv("DTS_KBASE_TEST_ORCID"), err
+	accessToken := strings.TrimSpace(string(accessTokenBytes))
 
 	// check the access token against the KBase auth server
 	// and fetch the first ORCID associated with it

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -117,8 +117,9 @@ func breakdown() {
 func get(resource string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, resource, http.NoBody)
 	if err == nil {
-		fakeToken := base64.StdEncoding.EncodeToString([]byte("fake_token"))
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", fakeToken))
+		accessToken := os.Getenv("DTS_KBASE_DEV_TOKEN")
+		b64Token := base64.StdEncoding.EncodeToString([]byte(accessToken))
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", b64Token))
 		return http.DefaultClient.Do(req)
 	} else {
 		return nil, err


### PR DESCRIPTION
The problem was a newline in the access token added by a decoding step.

Closes #20 