### PR TITLE
Canonicalized the DTS module path in go.mod and imports.

### DIFF
--- a/auth/kbase_auth_server_test.go
+++ b/auth/kbase_auth_server_test.go
@@ -28,16 +28,16 @@
 package auth
 
 import (
-	//	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // tests whether a proxy for the KBase authentication server can be
 // constructed
 func TestNewKBaseAuthServer(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 	devToken := os.Getenv("DTS_KBASE_DEV_TOKEN")
 	server, err := NewKBaseAuthServer(devToken)
 	assert.NotNil(server, "Authentication server not created")
@@ -47,7 +47,7 @@ func TestNewKBaseAuthServer(t *testing.T) {
 // tests whether the authentication server can return the proper credentials
 // for the owner of the developer token
 func TestOrchids(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 	devToken := os.Getenv("DTS_KBASE_DEV_TOKEN")
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 	assert.False(orcid == "")

--- a/config/config.go
+++ b/config/config.go
@@ -26,8 +26,6 @@ import (
 	"log"
 	"os"
 
-	//	"github.com/confluentinc/confluent-kafka-go/kafka"
-	//	"github.com/rabbitmq/amqp091-go"
 	"gopkg.in/yaml.v3"
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,9 +26,9 @@ package config
 import (
 	"fmt"
 	"os"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // a valid service config entry

--- a/core/frictionless.go
+++ b/core/frictionless.go
@@ -22,9 +22,10 @@
 package core
 
 import (
-	"dts/credit"
 	"encoding/json"
 	"strings"
+
+	"github.com/kbase/dts/credit"
 )
 
 // a Frictionless data package describing a set of related resources

--- a/core/task_manager_test.go
+++ b/core/task_manager_test.go
@@ -24,11 +24,11 @@ package core
 import (
 	"fmt"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // the interval at which our test task manager polls to update status
@@ -80,7 +80,7 @@ func breakdown() {
 }
 
 func TestNewTaskManager(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 
 	mgr, err := NewTaskManager(pollInterval)
 	assert.NotNil(mgr)
@@ -91,7 +91,7 @@ func TestNewTaskManager(t *testing.T) {
 }
 
 func TestAddTask(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 
 	mgr, err := NewTaskManager(pollInterval)
 	assert.Nil(err)

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -24,8 +24,8 @@ package databases
 import (
 	"fmt"
 
-	"dts/core"
-	"dts/databases/jdp"
+	"github.com/kbase/dts/core"
+	"github.com/kbase/dts/databases/jdp"
 )
 
 // we maintain a table of database instances, identified by their names

--- a/databases/databases_test.go
+++ b/databases/databases_test.go
@@ -1,13 +1,14 @@
 package databases
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewJDPDatabase(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 	jdpDb, err := NewDatabase(orcid, "jdp")
 	assert.NotNil(jdpDb, "JDP database not created")
@@ -15,7 +16,7 @@ func TestNewJDPDatabase(t *testing.T) {
 }
 
 func TestInvalidDatabase(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 	bbDb, err := NewDatabase(orcid, "booga booga")
 	assert.Nil(bbDb, "Invalid database should not be created")

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -36,10 +36,10 @@ import (
 
 	"github.com/google/uuid"
 
-	"dts/config"
-	"dts/core"
-	"dts/credit"
-	"dts/endpoints"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
+	"github.com/kbase/dts/credit"
+	"github.com/kbase/dts/endpoints"
 )
 
 const (

--- a/databases/jdp/database_test.go
+++ b/databases/jdp/database_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"dts/config"
-	"dts/core"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
 )
 
 const jdpConfig string = `

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -24,9 +24,9 @@ package endpoints
 import (
 	"fmt"
 
-	"dts/config"
-	"dts/core"
-	"dts/endpoints/globus"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
+	"github.com/kbase/dts/endpoints/globus"
 )
 
 // we maintain a table of endpoint instances, identified by their names

--- a/endpoints/endpoints_test.go
+++ b/endpoints/endpoints_test.go
@@ -1,11 +1,12 @@
 package endpoints
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 
-	"dts/config"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kbase/dts/config"
 )
 
 const globusConfig string = `
@@ -35,21 +36,21 @@ func breakdown() {
 }
 
 func TestNewGlobusEndpoint(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 	ep, err := NewEndpoint("globus")
 	assert.NotNil(ep, "Globus endpoint not created")
 	assert.Nil(err, "Globus endpoint creation encountered an error")
 }
 
 func TestInvalidEndpoint(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 	ep, err := NewEndpoint("invalid")
 	assert.Nil(ep, "Invalid endpoint somehow created")
 	assert.NotNil(err, "Invalid endpoint creation returned no error")
 }
 
 func TestNonexistentEndpoint(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 	ep, err := NewEndpoint("nonexistent")
 	assert.Nil(ep, "Nonexistent endpoint somehow created")
 	assert.NotNil(err, "Nonexistent endpoint creation returned no error")

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"dts/config"
-	"dts/core"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
 )
 
 // This file implements a Globus endpoint. It uses the Globus Transfer API

--- a/endpoints/globus/endpoint_test.go
+++ b/endpoints/globus/endpoint_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
-	"dts/config"
-	"dts/core"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
 )
 
 // source database files by ID
@@ -87,7 +87,7 @@ func TestGlobusConstructor(t *testing.T) {
 }
 
 func TestBadGlobusConstructor(t *testing.T) {
-	assert := assert.New(t) // binds assert to t
+	assert := assert.New(t)
 
 	endpoint, err := NewEndpoint("not-globus-jdp")
 	assert.Nil(endpoint)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dts
+module github.com/kbase/dts
 
 go 1.21.0
 

--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ import (
 	"syscall"
 	"time"
 
-	"dts/config"
-	"dts/services"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/services"
 )
 
 //go:generate mkdir -p services/docs

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -17,10 +17,10 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/net/netutil"
 
-	"dts/auth"
-	"dts/config"
-	"dts/core"
-	"dts/databases"
+	"github.com/kbase/dts/auth"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
+	"github.com/kbase/dts/databases"
 )
 
 // This type implements the TransferService interface, allowing file transfers

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
-	"dts/config"
-	"dts/core"
-	"dts/databases"
-	"dts/endpoints/globus"
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
+	"github.com/kbase/dts/databases"
+	"github.com/kbase/dts/endpoints/globus"
 )
 
 // working directory from which the tests were invoked

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"dts/core"
+	"github.com/kbase/dts/core"
 )
 
 // This package-specific helper function writes a JSON payload to an


### PR DESCRIPTION
This PR fixes the name of the DTS module and its packages, and does some minor cleanup. It should be merged after #25.