### PR TITLE
Implemented file manifest generation and relevant testing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,9 @@ type serviceConfig struct {
 	MaxConnections int `json:"max_connections" yaml:"max_connections"`
 	// polling interval for checking transfer statuses (seconds)
 	PollInterval int `json:"poll_interval" yaml:"poll_interval"`
+	// name of endpoint with access to local filesystem
+	// (for generating and transferring manifests)
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
 }
 
 // global config variables
@@ -87,6 +90,9 @@ func validateServiceParameters(params serviceConfig) error {
 	if params.MaxConnections <= 0 {
 		return fmt.Errorf("Invalid max_connections: %d (must be positive)",
 			params.MaxConnections)
+	}
+	if _, endpointFound := Endpoints[params.Endpoint]; !endpointFound {
+		return fmt.Errorf("Invalid service endpoint: %s", params.Endpoint)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -91,16 +91,15 @@ func validateServiceParameters(params serviceConfig) error {
 		return fmt.Errorf("Invalid max_connections: %d (must be positive)",
 			params.MaxConnections)
 	}
-	if _, endpointFound := Endpoints[params.Endpoint]; !endpointFound {
-		return fmt.Errorf("Invalid service endpoint: %s", params.Endpoint)
+	if params.Endpoint != "" {
+		if _, endpointFound := Endpoints[params.Endpoint]; !endpointFound {
+			return fmt.Errorf("Invalid service endpoint: %s", params.Endpoint)
+		}
 	}
 	return nil
 }
 
 func validateEndpoints(endpoints map[string]endpointConfig) error {
-	if len(endpoints) == 0 {
-		return fmt.Errorf("No endpoints were provided!")
-	}
 	for label, endpoint := range endpoints {
 		if endpoint.Id.String() == "" { // invalid endpoint UUID
 			return fmt.Errorf("Invalid UUID specified for endpoint '%s'", label)
@@ -112,9 +111,6 @@ func validateEndpoints(endpoints map[string]endpointConfig) error {
 }
 
 func validateDatabases(databases map[string]databaseConfig) error {
-	if len(databases) == 0 {
-		return fmt.Errorf("No databases were provided!")
-	}
 	for name, db := range databases {
 		if db.Endpoint == "" {
 			return fmt.Errorf("No endpoint given for database '%s'", name)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,13 +62,6 @@ databases:
     endpoint: globus-jdp # local file transfer endpoint
 `
 
-// tests whether config.Init reports an error for blank input
-func TestInitRejectsBlankInput(t *testing.T) {
-	b := []byte("")
-	err := Init(b)
-	assert.NotNil(t, err, "Blank config didn't trigger an error.")
-}
-
 // tests whether config.Init reports an error for an invalid max number of
 // processes
 func TestInitRejectsBadPort(t *testing.T) {
@@ -91,14 +84,6 @@ func TestInitRejectsBadMaxConnections(t *testing.T) {
 	assert.NotNil(t, err, "Config with bad maxConnections didn't trigger an error.")
 }
 
-// tests whether config.Init rejects a configuration with no endpoints
-func TestInitRejectsNoEndpointsDefined(t *testing.T) {
-	yaml := VALID_SERVICE + VALID_DATABASES
-	b := []byte(yaml)
-	err := Init(b)
-	assert.NotNil(t, err, "Config with no endpoints didn't trigger an error.")
-}
-
 // tests whether config.Init rejects a configuration with invalid endpoints
 func TestInitRejectsInvalidEndpointType(t *testing.T) {
 	yaml := VALID_SERVICE + VALID_DATABASES +
@@ -106,14 +91,6 @@ func TestInitRejectsInvalidEndpointType(t *testing.T) {
 	b := []byte(yaml)
 	err := Init(b)
 	assert.NotNil(t, err, "Config with invalid endpoint didn't trigger an error.")
-}
-
-// tests whether config.Init rejects a configuration with no databases
-func TestInitRejectsNoDatabasesDefined(t *testing.T) {
-	yaml := VALID_SERVICE + VALID_ENDPOINTS
-	b := []byte(yaml)
-	err := Init(b)
-	assert.NotNil(t, err, "Config with no databases didn't trigger an error.")
 }
 
 // Tests whether config.Init rejects a database with a bad base URL.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,7 @@ service:
   port: 8080
   max_connections: 100
   poll_interval: 60
+  endpoint: my-globus-endpoint
 `
 
 // a valid endpoints config entry

--- a/config/endpoint_config.go
+++ b/config/endpoint_config.go
@@ -12,5 +12,7 @@ type endpointConfig struct {
 	// the name of the provider (e.g. "globus")
 	Provider string `yaml:"provider"`
 	// authentication/authorization data (client secret used to request access token)
-	Auth authConfig `yaml:"auth"`
+	Auth authConfig `yaml:"auth,omitempty"`
+	// root directory for filesystem access (optional)
+	Root string `yaml:"root,omitempty"`
 }

--- a/core/database.go
+++ b/core/database.go
@@ -68,5 +68,5 @@ type Database interface {
 	// returns the status of a given staging operation
 	StagingStatus(id uuid.UUID) (StagingStatus, error)
 	// returns the endpoint associated with this database
-	Endpoint() Endpoint
+	Endpoint() (Endpoint, error)
 }

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -59,6 +59,9 @@ type TransferStatus struct {
 
 // This type represents an endpoint for transferring files.
 type Endpoint interface {
+	// returns a local endpoint that the DTS may use to transfer files directly
+	// to this endpoint
+	LocalEndpoint() (Endpoint, error)
 	// returns true if the files associated with the given DataResources are
 	// staged at this endpoint AND are valid, false otherwise
 	FilesStaged(files []DataResource) (bool, error)

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -59,6 +59,8 @@ type TransferStatus struct {
 
 // This type represents an endpoint for transferring files.
 type Endpoint interface {
+	// returns the path on the file system that serves as the endpoint's root
+	Root() string
 	// returns true if the files associated with the given DataResources are
 	// staged at this endpoint AND are valid, false otherwise
 	FilesStaged(files []DataResource) (bool, error)

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -38,12 +38,13 @@ type FileTransfer struct {
 type TransferStatusCode int
 
 const (
-	TransferStatusUnknown   TransferStatusCode = iota
-	TransferStatusStaging                      // files being staged
-	TransferStatusActive                       // transfer in progress
-	TransferStatusInactive                     // transfer suspended
-	TransferStatusSucceeded                    // transfer completed successfully
-	TransferStatusFailed                       // transfer failed
+	TransferStatusUnknown    TransferStatusCode = iota
+	TransferStatusStaging                       // files being staged
+	TransferStatusActive                        // transfer in progress
+	TransferStatusInactive                      // transfer suspended
+	TransferStatusFinalizing                    // transfer manifest being generated
+	TransferStatusSucceeded                     // transfer completed successfully
+	TransferStatusFailed                        // transfer failed
 )
 
 // this type conveys various information about a file transfer's status

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -59,9 +59,6 @@ type TransferStatus struct {
 
 // This type represents an endpoint for transferring files.
 type Endpoint interface {
-	// returns a local endpoint that the DTS may use to transfer files directly
-	// to this endpoint
-	LocalEndpoint() (Endpoint, error)
 	// returns true if the files associated with the given DataResources are
 	// staged at this endpoint AND are valid, false otherwise
 	FilesStaged(files []DataResource) (bool, error)

--- a/core/task_manager.go
+++ b/core/task_manager.go
@@ -135,13 +135,20 @@ func processTasks(channels channelsType) {
 					if task.Staging.Valid {
 						// are the files staged?
 						staged, err = endpoint.FilesStaged(task.Resources)
-						if staged { // yup -- start the transfer
+						if staged {
 							slog.Info(fmt.Sprintf("File staging for task %s completed successfully.", taskId.String()))
+
+							// generate a manifest for the transfer and send it to the
+							// source endpoint
+							// FIXME: this adds a new stage to the transfer process, so this
+							// FIXME: code needs restructuring.
+
+							// initiate the transfer (including the manifest)
 							fileXfers := make([]FileTransfer, len(task.Resources))
 							for i, resource := range task.Resources {
 								fileXfers[i] = FileTransfer{
 									SourcePath:      resource.Path,
-									DestinationPath: resource.Path,
+									DestinationPath: resource.Path, // FIXME: needs updating to destination dir structure
 									Hash:            resource.Hash,
 								}
 							}

--- a/core/task_manager.go
+++ b/core/task_manager.go
@@ -53,10 +53,15 @@ type taskType struct {
 // information being managed--that just creates other abstraction problems.
 func (task *taskType) Update() error {
 	username := "user" // FIXME: how do we obtain this from our Orcid ID?
-	sourceEndpoint := task.Source.Endpoint()
-	destinationEndpoint := task.Destination.Endpoint()
+	sourceEndpoint, err := task.Source.Endpoint()
+	if err != nil {
+		return err
+	}
+	destinationEndpoint, err := task.Destination.Endpoint()
+	if err != nil {
+		return err
+	}
 
-	var err error
 	if task.Resources == nil { // new task!
 		// resolve file paths using file IDs
 		task.Resources, err = task.Source.Resources(task.FileIds)

--- a/core/task_manager_test.go
+++ b/core/task_manager_test.go
@@ -211,8 +211,8 @@ func (db *FakeDatabase) StagingStatus(id uuid.UUID) (StagingStatus, error) {
 	}
 }
 
-func (db *FakeDatabase) Endpoint() Endpoint {
-	return db.Endpt
+func (db *FakeDatabase) Endpoint() (Endpoint, error) {
+	return db.Endpt, nil
 }
 
 type TransferInfo struct {

--- a/core/task_manager_test.go
+++ b/core/task_manager_test.go
@@ -82,7 +82,7 @@ func breakdown() {
 func TestNewTaskManager(t *testing.T) {
 	assert := assert.New(t)
 
-	mgr, err := NewTaskManager(pollInterval)
+	mgr, err := NewTaskManager(NewFakeEndpoint(), pollInterval)
 	assert.NotNil(mgr)
 	assert.Nil(err)
 	assert.Equal(pollInterval, mgr.PollInterval)
@@ -93,18 +93,25 @@ func TestNewTaskManager(t *testing.T) {
 func TestAddTask(t *testing.T) {
 	assert := assert.New(t)
 
-	mgr, err := NewTaskManager(pollInterval)
+	mgr, err := NewTaskManager(NewFakeEndpoint(), pollInterval)
 	assert.Nil(err)
 
 	// queue up a transfer task between two phony databases
 	src := NewFakeDatabase()
 	dest := NewFakeDatabase()
-	taskId, err := mgr.Add(src, dest, []string{"file1", "file2"})
+	orcid := "1234-5678-9012-3456"
+	taskId, err := mgr.Add(orcid, src, dest, []string{"file1", "file2"})
 	assert.Nil(err)
 	assert.True(taskId != uuid.UUID{})
 
-	// check its status (should be staging)
+	// the initial status of the task should be Unknown
 	status, err := mgr.Status(taskId)
+	assert.Nil(err)
+	assert.Equal(TransferStatusUnknown, status.Code)
+
+	// make sure the status switches to staging
+	time.Sleep(pause + pollInterval)
+	status, err = mgr.Status(taskId)
 	assert.Nil(err)
 	assert.Equal(TransferStatusStaging, status.Code)
 
@@ -116,11 +123,19 @@ func TestAddTask(t *testing.T) {
 	assert.Equal(TransferStatusActive, status.Code)
 
 	// wait again for the transfer to complete and then check its status
-	// (should have successfully completed)
+	// (should be finalizing or have successfully completed)
 	time.Sleep(pause + transferDuration)
 	status, err = mgr.Status(taskId)
 	assert.Nil(err)
-	assert.Equal(TransferStatusSucceeded, status.Code)
+	assert.True(status.Code == TransferStatusFinalizing || status.Code == TransferStatusSucceeded)
+
+	// if the transfer was finalizing, check once more for completion
+	if status.Code != TransferStatusSucceeded {
+		time.Sleep(pause + transferDuration)
+		status, err = mgr.Status(taskId)
+		assert.Nil(err)
+		assert.Equal(TransferStatusSucceeded, status.Code)
+	}
 
 	mgr.Close()
 }

--- a/core/task_manager_test.go
+++ b/core/task_manager_test.go
@@ -237,6 +237,11 @@ func NewFakeEndpoint() *FakeEndpoint {
 	}
 }
 
+func (ep *FakeEndpoint) Root() string {
+	root, _ := os.Getwd()
+	return root
+}
+
 func (ep *FakeEndpoint) FilesStaged(files []DataResource) (bool, error) {
 	if ep.Database != nil {
 		// are there any unrecognized files?

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -532,7 +532,6 @@ func (db *Database) StagingStatus(id uuid.UUID) (core.StagingStatus, error) {
 	}
 }
 
-func (db *Database) Endpoint() core.Endpoint {
-	endpoint, _ := endpoints.NewEndpoint(config.Databases[db.Id].Endpoint)
-	return endpoint
+func (db *Database) Endpoint() (core.Endpoint, error) {
+	return endpoints.NewEndpoint(config.Databases[db.Id].Endpoint)
 }

--- a/databases/jdp/database_test.go
+++ b/databases/jdp/database_test.go
@@ -119,7 +119,8 @@ func TestEndpoint(t *testing.T) {
 	assert := assert.New(t)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 	db, _ := NewDatabase(orcid)
-	endpoint := db.Endpoint()
+	endpoint, err := db.Endpoint()
+	assert.Nil(err)
 	assert.NotNil(endpoint, "JDP database has no endpoint")
 }
 

--- a/databases/jdp/fixtures/dts-jamo-cassette.yaml
+++ b/databases/jdp/fixtures/dts-jamo-cassette.yaml
@@ -12,7 +12,7 @@ interactions:
         host: jamo-dev.jgi.doe.gov
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"select _id, file_name, file_path, metadata.file_format, file_size, md5_sum where _id in ( 57f9e03f7ded5e3135bc069e, 57f9d2b57ded5e3135bc0612, 57f9bcb77ded5e3135bc05a5, 57f7e5c47ded5e3135bbd21e, 582509de7ded5e2d305af5d2, 584486257ded5e2d305c9a5c, 57f806ef7ded5e3135bbd583, 582509dd7ded5e2d305af5d1, 584486237ded5e2d305c9a57, 584486237ded5e2d305c9a58 )","requestor":"dts@kbase.us"}'
+        body: '{"query":"select _id, file_name, file_path, metadata.file_format, file_size, md5_sum where _id in ( 57f9e03f7ded5e3135bc069e, 57f9d2b57ded5e3135bc0612, 57f9bcb77ded5e3135bc05a5, 57f7e5c47ded5e3135bbd21e, 582509de7ded5e2d305af5d2, 584486257ded5e2d305c9a5c, 57f806ef7ded5e3135bbd583, 582509dd7ded5e2d305af5d1, 584486237ded5e2d305c9a58, 584486247ded5e2d305c9a5a )","requestor":"dts@kbase.us"}'
         form: {}
         headers:
             Content-Type:
@@ -27,7 +27,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"start": 1, "end": 10, "cursor_id": "VX6CJIDMP0", "record_count": 10, "records": [{"_id": "57f7e5c47ded5e3135bbd21e", "file_name": "10914.1.183618.CTCTCTA-ATTAGAC.QC.pdf", "metadata": {}, "file_size": 229766, "file_path": "/global/dna/dm_archive/rqc"}, {"_id": "57f806ef7ded5e3135bbd583", "file_name": "10914.1.183618.CTCTCTA-ATTAGAC.filter-SAG.fastq.gz", "file_size": 2322775655, "file_path": "/global/dna/dm_archive/rqc/filtered_seq_unit/00/01/09/14", "metadata": {}}, {"_id": "57f9bcb77ded5e3135bc05a5", "file_name": "10927.1.183804.CTCTCTA-AGGCTTA.fastq.gz", "file_size": 1966895000, "file_path": "/global/dna/dm_archive/sdm/illumina/01/09/27", "metadata": {}}, {"_id": "57f9d2b57ded5e3135bc0612", "file_name": "10927.1.183804.CTCTCTA-AGGCTTA.filter-SAG.fastq.gz", "file_size": 2225019092, "file_path": "/global/dna/dm_archive/rqc/filtered_seq_unit/00/01/09/27", "metadata": {}}, {"_id": "57f9e03f7ded5e3135bc069e", "file_name": "10927.1.183804.CTCTCTA-AGGCTTA.QC.pdf", "metadata": {}, "file_size": 227745, "file_path": "/global/dna/dm_archive/rqc"}, {"_id": "582509dd7ded5e2d305af5d1", "file_name": "sag-BHAPU-screen.pdf", "file_size": 692808, "file_path": "/global/dna/dm_archive/qaqc/analyses/AUTO-33721", "metadata": {"file_format": "pdf"}}, {"_id": "582509de7ded5e2d305af5d2", "file_name": "sag-BHAPU-screen.txt", "file_size": 4272, "file_path": "/global/dna/dm_archive/qaqc/analyses/AUTO-33721", "metadata": {"file_format": "txt"}}, {"_id": "584486237ded5e2d305c9a57", "file_name": "101341.assembled.fna", "file_size": 1151157, "file_path": "/global/dna/dm_archive/img/submissions/101341", "metadata": {}}, {"_id": "584486237ded5e2d305c9a58", "file_name": "101341.assembled.faa", "file_size": 370266, "file_path": "/global/dna/dm_archive/img/submissions/101341", "metadata": {}}, {"_id": "584486257ded5e2d305c9a5c", "file_name": "101341.assembled.gbk", "file_size": 2282302, "file_path": "/global/dna/dm_archive/img/submissions/101341", "metadata": {}}], "fields": ["_id", "file_name", "file_path", "metadata.file_format", "file_size", "md5_sum"], "timeout": 180}'
+        body: '{"start": 1, "end": 10, "cursor_id": "ZRNUC82CWA", "record_count": 10, "records": [{"_id": "57f7e5c47ded5e3135bbd21e", "file_name": "10914.1.183618.CTCTCTA-ATTAGAC.QC.pdf", "metadata": {}, "file_size": 229766, "file_path": "/global/dna/dm_archive/rqc"}, {"_id": "57f806ef7ded5e3135bbd583", "file_name": "10914.1.183618.CTCTCTA-ATTAGAC.filter-SAG.fastq.gz", "file_size": 2322775655, "file_path": "/global/dna/dm_archive/rqc/filtered_seq_unit/00/01/09/14", "metadata": {}}, {"_id": "57f9bcb77ded5e3135bc05a5", "file_name": "10927.1.183804.CTCTCTA-AGGCTTA.fastq.gz", "file_size": 1966895000, "file_path": "/global/dna/dm_archive/sdm/illumina/01/09/27", "metadata": {}}, {"_id": "57f9d2b57ded5e3135bc0612", "file_name": "10927.1.183804.CTCTCTA-AGGCTTA.filter-SAG.fastq.gz", "file_size": 2225019092, "file_path": "/global/dna/dm_archive/rqc/filtered_seq_unit/00/01/09/27", "metadata": {}}, {"_id": "57f9e03f7ded5e3135bc069e", "file_name": "10927.1.183804.CTCTCTA-AGGCTTA.QC.pdf", "metadata": {}, "file_size": 227745, "file_path": "/global/dna/dm_archive/rqc"}, {"_id": "582509dd7ded5e2d305af5d1", "file_name": "sag-BHAPU-screen.pdf", "file_size": 692808, "file_path": "/global/dna/dm_archive/qaqc/analyses/AUTO-33721", "metadata": {"file_format": "pdf"}}, {"_id": "582509de7ded5e2d305af5d2", "file_name": "sag-BHAPU-screen.txt", "file_size": 4272, "file_path": "/global/dna/dm_archive/qaqc/analyses/AUTO-33721", "metadata": {"file_format": "txt"}}, {"_id": "584486237ded5e2d305c9a58", "file_name": "101341.assembled.faa", "file_size": 370266, "file_path": "/global/dna/dm_archive/img/submissions/101341", "metadata": {}}, {"_id": "584486247ded5e2d305c9a5a", "file_name": "101341.assembled.gff", "file_size": 187141, "file_path": "/global/dna/dm_archive/img/submissions/101341", "metadata": {}}, {"_id": "584486257ded5e2d305c9a5c", "file_name": "101341.assembled.gbk", "file_size": 2282302, "file_path": "/global/dna/dm_archive/img/submissions/101341", "metadata": {}}], "fields": ["_id", "file_name", "file_path", "metadata.file_format", "file_size", "md5_sum"], "timeout": 180}'
         headers:
             Access-Control-Allow-Headers:
                 - Content-Type, Authorization, X-Requested-With
@@ -40,11 +40,11 @@ interactions:
             Cf-Cache-Status:
                 - DYNAMIC
             Cf-Ray:
-                - 82ddbe6ecb0d682f-SEA
+                - 83fd4d3afa37ec4c-SEA
             Content-Type:
                 - application/json;charset=utf-8
             Date:
-                - Wed, 29 Nov 2023 20:54:06 GMT
+                - Wed, 03 Jan 2024 18:28:28 GMT
             Server:
                 - cloudflare
             Vary:
@@ -53,4 +53,4 @@ interactions:
                 - 1.1 jamo-dev.jgi.doe.gov
         status: 200 OK
         code: 200
-        duration: 396.787144ms
+        duration: 407.44318ms

--- a/databases/jdp/jamo.go
+++ b/databases/jdp/jamo.go
@@ -83,7 +83,7 @@ func queryJamo(fileIds []string) ([]jamoFileRecord, error) {
 	// for fetching file paths, and since JAMO only works within LBL's VPN)
 	var recordingMode recorder.Mode
 	if _, onVPN := os.LookupEnv("DTS_ON_LBL_VPN"); onVPN {
-		recordingMode = recorder.ModeRecordOnce
+		recordingMode = recorder.ModeRecordOnly
 	} else {
 		recordingMode = recorder.ModeReplayOnly
 	}

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -52,8 +52,20 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 		if err == nil {
 			allEndpoints[endpointName] = endpoint
 		}
-	} else {
-		err = fmt.Errorf("Invalid endpoint: %s", endpointName)
 	}
 	return endpoint, err
+}
+
+// creates a "local" endpoint, for use by the DTS itself in transmitting file
+// manifests, based on the type of the given destination endpoint
+func NewLocalEndpoint(destinationEndpoint core.Endpoint) (core.Endpoint, error) {
+	var localEndpoint core.Endpoint
+	var err error
+	switch destinationEndpoint.(type) {
+	case *globus.Endpoint:
+		localEndpoint, err = globus.LocalEndpoint()
+	default:
+		err = fmt.Errorf("Invalid destination endpoint type!")
+	}
+	return localEndpoint, err
 }

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -55,17 +55,3 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	}
 	return endpoint, err
 }
-
-// creates a "local" endpoint, for use by the DTS itself in transmitting file
-// manifests, based on the type of the given destination endpoint
-func NewLocalEndpoint(destinationEndpoint core.Endpoint) (core.Endpoint, error) {
-	var localEndpoint core.Endpoint
-	var err error
-	switch destinationEndpoint.(type) {
-	case *globus.Endpoint:
-		localEndpoint, err = globus.LocalEndpoint()
-	default:
-		err = fmt.Errorf("Invalid destination endpoint type!")
-	}
-	return localEndpoint, err
-}

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kbase/dts/config"
 	"github.com/kbase/dts/core"
 	"github.com/kbase/dts/endpoints/globus"
+	"github.com/kbase/dts/endpoints/local"
 )
 
 // we maintain a table of endpoint instances, identified by their names
@@ -40,10 +41,12 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	// do we have one of these already?
 	endpoint, found := allEndpoints[endpointName]
 	if !found {
-		// is it a Globus endpoint?
-		if config.Endpoints[endpointName].Provider == "globus" {
+		switch config.Endpoints[endpointName].Provider {
+		case "globus":
 			endpoint, err = globus.NewEndpoint(endpointName)
-		} else {
+		case "local":
+			endpoint, err = local.NewEndpoint(endpointName)
+		default:
 			err = fmt.Errorf("Invalid provider for endpoint '%s': %s", endpointName,
 				config.Endpoints[endpointName].Provider)
 		}

--- a/endpoints/endpoints_test.go
+++ b/endpoints/endpoints_test.go
@@ -56,16 +56,6 @@ func TestNonexistentEndpoint(t *testing.T) {
 	assert.NotNil(err, "Nonexistent endpoint creation returned no error")
 }
 
-func TestLocalEndpoint(t *testing.T) {
-	assert := assert.New(t)
-	destEp, err := NewEndpoint("globus")
-	assert.NotNil(ep, "Globus endpoint not created")
-	assert.Nil(err, "Globus endpoint creation encountered an error")
-	localEp, err := destEp.LocalEndpoint()
-	assert.NotNil(ep, "Local Globus endpoint not created")
-	assert.Nil(err, "Local Globus endpoint creation encountered an error")
-}
-
 // this runs setup, runs all tests, and does breakdown
 func TestMain(m *testing.M) {
 	var status int

--- a/endpoints/endpoints_test.go
+++ b/endpoints/endpoints_test.go
@@ -56,12 +56,12 @@ func TestNonexistentEndpoint(t *testing.T) {
 	assert.NotNil(err, "Nonexistent endpoint creation returned no error")
 }
 
-func TestNewLocalGlobusEndpoint(t *testing.T) {
+func TestLocalEndpoint(t *testing.T) {
 	assert := assert.New(t)
 	destEp, err := NewEndpoint("globus")
 	assert.NotNil(ep, "Globus endpoint not created")
 	assert.Nil(err, "Globus endpoint creation encountered an error")
-	localEp, err := NewLocalEndpoint(destEp)
+	localEp, err := destEp.LocalEndpoint()
 	assert.NotNil(ep, "Local Globus endpoint not created")
 	assert.Nil(err, "Local Globus endpoint creation encountered an error")
 }

--- a/endpoints/endpoints_test.go
+++ b/endpoints/endpoints_test.go
@@ -56,6 +56,16 @@ func TestNonexistentEndpoint(t *testing.T) {
 	assert.NotNil(err, "Nonexistent endpoint creation returned no error")
 }
 
+func TestNewLocalGlobusEndpoint(t *testing.T) {
+	assert := assert.New(t)
+	destEp, err := NewEndpoint("globus")
+	assert.NotNil(ep, "Globus endpoint not created")
+	assert.Nil(err, "Globus endpoint creation encountered an error")
+	localEp, err := NewLocalEndpoint(destEp)
+	assert.NotNil(ep, "Local Globus endpoint not created")
+	assert.Nil(err, "Local Globus endpoint creation encountered an error")
+}
+
 // this runs setup, runs all tests, and does breakdown
 func TestMain(m *testing.M) {
 	var status int

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -79,6 +79,9 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	if epConfig.Provider != "globus" {
 		return nil, fmt.Errorf("'%s' is not a Globus endpoint", endpointName)
 	}
+	if epConfig.Root != "" {
+		return nil, fmt.Errorf("As a Globus endpoint, '%s' cannot have its root directory specified", endpointName)
+	}
 
 	ep := &Endpoint{
 		Name: epConfig.Name,

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -94,7 +94,7 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 // files (e. g. manifests) and transfer them to other endpoints
 func NewConnectPersonalEndpoint() (core.Endpoint, error) {
 	// FIXME
-	var ep Endpoint
+	var ep *Endpoint
 	var err error
 	return ep, err
 }

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -67,6 +67,8 @@ type Endpoint struct {
 	AccessToken string
 }
 
+// creates a new Globus endpoint using the information supplied in the
+// DTS configuration file under the given endpoint name
 func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	epConfig, found := config.Endpoints[endpointName]
 	if !found {
@@ -85,6 +87,15 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	err := ep.authenticate(epConfig.Auth.ClientId,
 		epConfig.Auth.ClientSecret)
 
+	return ep, err
+}
+
+// creates a Globus Connect Personal endpoint that the DTS can use to create
+// files (e. g. manifests) and transfer them to other endpoints
+func NewConnectPersonalEndpoint() (core.Endpoint, error) {
+	// FIXME
+	var ep Endpoint
+	var err error
 	return ep, err
 }
 

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -90,13 +90,16 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	return ep, err
 }
 
-// creates a Globus Connect Personal endpoint that the DTS can use to create
-// files (e. g. manifests) and transfer them to other endpoints
-func NewConnectPersonalEndpoint() (core.Endpoint, error) {
-	// FIXME
-	var ep *Endpoint
+var localEndpoint *Endpoint
+
+// creates or returns the single local Globus endpoint that the DTS uses to
+// create files (e. g. manifests) and transfer them to other endpoints
+func LocalEndpoint() (core.Endpoint, error) {
 	var err error
-	return ep, err
+	if localEndpoint == nil {
+		// FIXME
+	}
+	return localEndpoint, err
 }
 
 // authenticates with Globus using a client ID and secret to obtain an access

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -90,18 +90,6 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	return ep, err
 }
 
-var localEndpoint *Endpoint
-
-// creates or returns the single local Globus endpoint that the DTS uses to
-// create files (e. g. manifests) and transfer them to other endpoints
-func LocalEndpoint() (core.Endpoint, error) {
-	var err error
-	if localEndpoint == nil {
-		// FIXME
-	}
-	return localEndpoint, err
-}
-
 // authenticates with Globus using a client ID and secret to obtain an access
 // token (https://docs.globus.org/api/auth/reference/#client_credentials_grant)
 func (ep *Endpoint) authenticate(clientId uuid.UUID, clientSecret string) error {
@@ -197,6 +185,16 @@ func (ep *Endpoint) post(resource string, body io.Reader) (*http.Response, error
 		}
 	}
 	return nil, err
+}
+
+var localEndpoint *Endpoint
+
+func (ep *Endpoint) LocalEndpoint() (core.Endpoint, error) {
+	var err error
+	if localEndpoint == nil {
+		// FIXME
+	}
+	return localEndpoint, err
 }
 
 func (ep *Endpoint) FilesStaged(files []core.DataResource) (bool, error) {

--- a/endpoints/local/endpoint.go
+++ b/endpoints/local/endpoint.go
@@ -58,22 +58,21 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 	if epConfig.Provider != "local" {
 		return nil, fmt.Errorf("'%s' is not a local endpoint", endpointName)
 	}
-
-	cwd, err := os.Getwd()
-	if err == nil {
-		return &Endpoint{
-			Name:  epConfig.Name,
-			Id:    epConfig.Id,
-			root:  cwd,
-			Xfers: make(map[uuid.UUID]core.TransferStatus),
-		}, nil
-	} else {
-		return nil, err
+	if epConfig.Root == "" {
+		return nil, fmt.Errorf("'%s' requires a root directory to be specified", endpointName)
 	}
+
+	ep := &Endpoint{
+		Name:  epConfig.Name,
+		Id:    epConfig.Id,
+		Xfers: make(map[uuid.UUID]core.TransferStatus),
+	}
+	err := ep.setRoot(epConfig.Root)
+	return ep, err
 }
 
-// sets the root directory for the local endpoint
-func (ep *Endpoint) SetRoot(dir string) error {
+// sets the root directory for the local endpoint after checking that it exists
+func (ep *Endpoint) setRoot(dir string) error {
 	_, err := os.Stat(dir)
 	if err == nil {
 		ep.root = dir

--- a/endpoints/local/endpoint.go
+++ b/endpoints/local/endpoint.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package local
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
+)
+
+// This file implements an endpoint that moves files around on a local
+// file system. It's used only for testing.
+
+type Endpoint struct {
+	// descriptive endpoint name (obtained from config)
+	Name string
+	// endpoint UUID (obtained from config)
+	Id uuid.UUID
+	// root directory for endpoint (default: current working directory)
+	Root string
+	// transfers in progress
+	Xfers map[uuid.UUID]core.TransferStatus
+}
+
+// creates a new local endpoint using the information supplied in the
+// DTS configuration file under the given endpoint name
+func NewEndpoint(endpointName string) (core.Endpoint, error) {
+	epConfig, found := config.Endpoints[endpointName]
+	if !found {
+		return nil, fmt.Errorf("'%s' is not an endpoint", endpointName)
+	}
+	if epConfig.Provider != "local" {
+		return nil, fmt.Errorf("'%s' is not a local endpoint", endpointName)
+	}
+
+	cwd, err := os.Getwd()
+	if err == nil {
+		return &Endpoint{
+			Name:  epConfig.Name,
+			Id:    epConfig.Id,
+			Root:  cwd,
+			Xfers: make(map[uuid.UUID]core.TransferStatus),
+		}, nil
+	} else {
+		return nil, err
+	}
+}
+
+// sets the root directory for the local endpoint
+func (ep *Endpoint) SetRoot(dir string) error {
+	_, err := os.Stat(dir)
+	if err == nil {
+		ep.Root = dir
+	}
+	return err
+}
+
+func (ep *Endpoint) FilesStaged(files []core.DataResource) (bool, error) {
+	for _, resource := range files {
+		absPath := filepath.Join(ep.Root, resource.Path)
+		_, err := os.Stat(absPath)
+		if err != nil {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (ep *Endpoint) Transfers() ([]uuid.UUID, error) {
+	xfers := make([]uuid.UUID, 0)
+	for xferId, xferStatus := range ep.Xfers {
+		switch xferStatus.Code {
+		case core.TransferStatusSucceeded, core.TransferStatusFailed:
+		default:
+			xfers = append(xfers, xferId)
+		}
+	}
+	return xfers, nil
+}
+
+// implements asynchronous local file transfers and validation
+func (ep *Endpoint) transferFiles(xferId uuid.UUID, files []core.FileTransfer) {
+	for _, file := range files {
+		sourcePath := filepath.Join(ep.Root, file.SourcePath)
+		destPath := filepath.Join(ep.Root, file.DestinationPath)
+
+		// create the destination directory if needed
+		sourceDir := filepath.Dir(sourcePath)
+		sourceDirInfo, err := os.Stat(sourceDir)
+		destDir := filepath.Dir(destPath)
+		_, err = os.Stat(destDir)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				os.Mkdir(destDir, sourceDirInfo.Mode())
+			} else {
+				status := ep.Xfers[xferId]
+				status.Code = core.TransferStatusFailed
+				ep.Xfers[xferId] = status
+				break
+			}
+		}
+
+		// copy the file into place
+		sourceInfo, err := os.Stat(sourcePath)
+		if err == nil {
+			data, err := os.ReadFile(sourcePath)
+			if err == nil {
+				err = os.WriteFile(destPath, data, sourceInfo.Mode())
+			}
+		}
+		status := ep.Xfers[xferId]
+		if err == nil {
+			status.NumFilesTransferred++
+			ep.Xfers[xferId] = status
+		} else {
+			status.Code = core.TransferStatusFailed
+			ep.Xfers[xferId] = status
+			break
+		}
+	}
+	status := ep.Xfers[xferId]
+	status.Code = core.TransferStatusSucceeded
+	ep.Xfers[xferId] = status
+}
+
+func (ep *Endpoint) Transfer(dst core.Endpoint, files []core.FileTransfer) (uuid.UUID, error) {
+	_, ok := dst.(*Endpoint)
+	if !ok {
+		return uuid.UUID{}, fmt.Errorf("Destination endpoint must be local!")
+	}
+
+	// first, we check that all requested files are staged on this endpoint
+	requestedFiles := make([]core.DataResource, len(files))
+	for i, file := range files {
+		requestedFiles[i].Path = file.SourcePath // only the Path field is required
+	}
+	staged, err := ep.FilesStaged(requestedFiles)
+	if err == nil && staged {
+		// assign a UUID to the transfer and set it going
+		xferId := uuid.New()
+		ep.Xfers[xferId] = core.TransferStatus{
+			Code:                core.TransferStatusActive,
+			NumFiles:            len(files),
+			NumFilesTransferred: 0,
+		}
+		go ep.transferFiles(xferId, files)
+		return xferId, nil
+	} else {
+		if err == nil {
+			err = fmt.Errorf("The files requested for transfer are not yet staged.")
+		}
+		return uuid.UUID{}, err
+	}
+}
+
+func (ep *Endpoint) Status(id uuid.UUID) (core.TransferStatus, error) {
+	if xferStatus, found := ep.Xfers[id]; found {
+		return xferStatus, nil
+	} else {
+		return core.TransferStatus{
+			Code: core.TransferStatusUnknown,
+		}, fmt.Errorf("Transfer %s not found!", id.String())
+	}
+}
+
+func (ep *Endpoint) Cancel(id uuid.UUID) error {
+	return fmt.Errorf("Local transfers cannot be canceled!")
+}

--- a/endpoints/local/endpoint.go
+++ b/endpoints/local/endpoint.go
@@ -43,7 +43,7 @@ type Endpoint struct {
 	// endpoint UUID (obtained from config)
 	Id uuid.UUID
 	// root directory for endpoint (default: current working directory)
-	Root string
+	root string
 	// transfers in progress
 	Xfers map[uuid.UUID]core.TransferStatus
 }
@@ -64,7 +64,7 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 		return &Endpoint{
 			Name:  epConfig.Name,
 			Id:    epConfig.Id,
-			Root:  cwd,
+			root:  cwd,
 			Xfers: make(map[uuid.UUID]core.TransferStatus),
 		}, nil
 	} else {
@@ -76,14 +76,18 @@ func NewEndpoint(endpointName string) (core.Endpoint, error) {
 func (ep *Endpoint) SetRoot(dir string) error {
 	_, err := os.Stat(dir)
 	if err == nil {
-		ep.Root = dir
+		ep.root = dir
 	}
 	return err
 }
 
+func (ep *Endpoint) Root() string {
+	return ep.root
+}
+
 func (ep *Endpoint) FilesStaged(files []core.DataResource) (bool, error) {
 	for _, resource := range files {
-		absPath := filepath.Join(ep.Root, resource.Path)
+		absPath := filepath.Join(ep.root, resource.Path)
 		_, err := os.Stat(absPath)
 		if err != nil {
 			return false, nil
@@ -107,8 +111,8 @@ func (ep *Endpoint) Transfers() ([]uuid.UUID, error) {
 // implements asynchronous local file transfers and validation
 func (ep *Endpoint) transferFiles(xferId uuid.UUID, files []core.FileTransfer) {
 	for _, file := range files {
-		sourcePath := filepath.Join(ep.Root, file.SourcePath)
-		destPath := filepath.Join(ep.Root, file.DestinationPath)
+		sourcePath := filepath.Join(ep.root, file.SourcePath)
+		destPath := filepath.Join(ep.root, file.DestinationPath)
 
 		// create the destination directory if needed
 		sourceDir := filepath.Dir(sourcePath)

--- a/endpoints/local/endpoint.go
+++ b/endpoints/local/endpoint.go
@@ -109,10 +109,10 @@ func (ep *Endpoint) Transfers() ([]uuid.UUID, error) {
 }
 
 // implements asynchronous local file transfers and validation
-func (ep *Endpoint) transferFiles(xferId uuid.UUID, files []core.FileTransfer) {
+func (ep *Endpoint) transferFiles(xferId uuid.UUID, dest core.Endpoint, files []core.FileTransfer) {
 	for _, file := range files {
-		sourcePath := filepath.Join(ep.root, file.SourcePath)
-		destPath := filepath.Join(ep.root, file.DestinationPath)
+		sourcePath := filepath.Join(ep.Root(), file.SourcePath)
+		destPath := filepath.Join(dest.Root(), file.DestinationPath)
 
 		// create the destination directory if needed
 		sourceDir := filepath.Dir(sourcePath)
@@ -121,7 +121,7 @@ func (ep *Endpoint) transferFiles(xferId uuid.UUID, files []core.FileTransfer) {
 		_, err = os.Stat(destDir)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				os.Mkdir(destDir, sourceDirInfo.Mode())
+				os.MkdirAll(destDir, sourceDirInfo.Mode())
 			} else {
 				status := ep.Xfers[xferId]
 				status.Code = core.TransferStatusFailed
@@ -173,7 +173,7 @@ func (ep *Endpoint) Transfer(dst core.Endpoint, files []core.FileTransfer) (uuid
 			NumFiles:            len(files),
 			NumFilesTransferred: 0,
 		}
-		go ep.transferFiles(xferId, files)
+		go ep.transferFiles(xferId, dst, files)
 		return xferId, nil
 	} else {
 		if err == nil {

--- a/endpoints/local/endpoint_test.go
+++ b/endpoints/local/endpoint_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package local
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
+)
+
+var tempRoot string
+var sourceRoot string
+var destinationRoot string
+
+// source database files by ID
+var sourceFilesById = map[string]string{
+	"1": "file1.txt",
+	"2": "file2.txt",
+	"3": "file3.txt",
+}
+
+const localConfig string = `
+endpoints:
+  source:
+    name: Source Endpoint
+    id: 2ee69538-10d5-4d1e-a890-1127b5e42003
+    provider: local
+  destination:
+    name: Destination Endpoint
+    id: b925d96e-7e39-473b-a658-714f8c243b1c
+    provider: local
+`
+
+// this function gets called at the begіnning of a test session
+func setup() {
+	config.Init([]byte(localConfig))
+
+	// create source/destination directories
+	var err error
+	tempRoot, err = os.MkdirTemp(os.TempDir(), "dts-local-endpoints")
+	if err == nil {
+		sourceRoot = filepath.Join(tempRoot, "source")
+		err = os.Mkdir(sourceRoot, 0700)
+		if err == nil {
+			destinationRoot = filepath.Join(tempRoot, "destination")
+			err = os.Mkdir(destinationRoot, 0700)
+			if err == nil {
+				// create source files
+				for i := 1; i <= 3; i++ {
+					err = os.WriteFile(filepath.Join(sourceRoot, fmt.Sprintf("file%d.txt", i)),
+						[]byte(fmt.Sprintf("This is the content of file %d.", i)), 0600)
+					if err != nil {
+						break
+					}
+				}
+			}
+		}
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+
+// this function gets called after all tests have been run
+func breakdown() {
+	os.RemoveAll(tempRoot)
+}
+
+func TestLocalConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	endpoint, err := NewEndpoint("source")
+	assert.NotNil(endpoint)
+	assert.Nil(err)
+}
+
+func TestBadLocalConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	endpoint, err := NewEndpoint("nonexistent-endpoint")
+	assert.Nil(endpoint)
+	assert.NotNil(err)
+}
+
+func TestLocalTransfers(t *testing.T) {
+	assert := assert.New(t)
+	endpoint, _ := NewEndpoint("source")
+	// this is just a smoke test--we don't check the contents of the result
+	xfers, err := endpoint.Transfers()
+	assert.NotNil(xfers) // empty or non-empty slice
+	assert.Nil(err)
+}
+
+func TestGlobusFilesStaged(t *testing.T) {
+	assert := assert.New(t)
+	endpoint, _ := NewEndpoint("source")
+	localEp := endpoint.(*Endpoint)
+	localEp.SetRoot(sourceRoot)
+
+	// provide an empty slice of filenames, which should return true
+	staged, err := endpoint.FilesStaged([]core.DataResource{})
+	assert.True(staged)
+	assert.Nil(err)
+
+	// provide files that are known to be on the source endpoint
+	resources := make([]core.DataResource, 0)
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("%d", i)
+		resources = append(resources, core.DataResource{
+			Id:   id,
+			Path: sourceFilesById[id],
+		})
+	}
+	staged, err = endpoint.FilesStaged(resources)
+	assert.True(staged)
+	assert.Nil(err)
+
+	// provide a nonexistent file, which should return false
+	resources = []core.DataResource{
+		core.DataResource{
+			Id:   "yadda",
+			Path: "yaddayadda/yadda/yaddayadda/yaddayaddayadda.xml",
+		},
+	}
+	staged, err = endpoint.FilesStaged(resources)
+	assert.False(staged)
+	assert.Nil(err)
+}
+
+func TestLocalTransfer(t *testing.T) {
+	assert := assert.New(t)
+
+	source, _ := NewEndpoint("source")
+	localSourceEp := source.(*Endpoint)
+	localSourceEp.SetRoot(sourceRoot)
+
+	destination, _ := NewEndpoint("destination")
+	localDestEp := destination.(*Endpoint)
+	localDestEp.SetRoot(destinationRoot)
+
+	fileXfers := make([]core.FileTransfer, 0)
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("%d", i)
+
+		fileXfers = append(fileXfers, core.FileTransfer{
+			SourcePath:      sourceFilesById[id],
+			DestinationPath: sourceFilesById[id],
+		})
+	}
+	_, err := source.Transfer(destination, fileXfers)
+	assert.Nil(err)
+}
+
+func TestBadLocalTransfer(t *testing.T) {
+	assert := assert.New(t)
+	source, _ := NewEndpoint("source")
+	destination, _ := NewEndpoint("destination")
+
+	// ask for some nonexistent files
+	fileXfers := make([]core.FileTransfer, 0)
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("%d", i)
+		fileXfers = append(fileXfers, core.FileTransfer{
+			SourcePath:      sourceFilesById[id] + "_with_bad_suffix",
+			DestinationPath: sourceFilesById[id] + "_with_bad_suffix",
+		})
+	}
+	_, err := source.Transfer(destination, fileXfers)
+	assert.NotNil(err)
+}
+
+func TestUnknownLocalStatus(t *testing.T) {
+	assert := assert.New(t)
+	endpoint, _ := NewEndpoint("source")
+
+	// make up a bogus transfer UUID and check its status
+	taskId := uuid.New()
+	status, err := endpoint.Status(taskId)
+	assert.Equal(core.TransferStatusUnknown, status.Code)
+	assert.NotNil(err)
+}
+
+// this runs setup, runs all tests, and does breakdown
+func TestMain(m *testing.M) {
+	var status int
+	setup()
+	status = m.Run()
+	breakdown()
+	os.Exit(status)
+}

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"log/slog"
 	"os"
@@ -73,7 +73,7 @@ func main() {
 	}
 	defer file.Close()
 
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		log.Panicf("Couldn't read configuration data: %s\n", err.Error())
 	}

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -397,6 +397,18 @@ func (service *prototype) uptime() float64 {
 
 // constructs a prototype file transfer service given our configuration
 func NewDTSPrototype() (TransferService, error) {
+
+	// validate our configuration
+	if config.Service.Endpoint == "" {
+		return nil, fmt.Errorf("No service endpoint was specified.")
+	}
+	if len(config.Databases) == 0 {
+		return nil, fmt.Errorf("No databases were specified.")
+	}
+	if len(config.Endpoints) == 0 {
+		return nil, fmt.Errorf("No endpoints were specified.")
+	}
+
 	service := new(prototype)
 	service.Name = "DTS prototype"
 	service.Version = core.Version
@@ -448,6 +460,9 @@ func (service *prototype) Start(port int) error {
 	listener = netutil.LimitListener(listener, config.Service.MaxConnections)
 
 	localEndpoint, err := endpoints.NewEndpoint(config.Service.Endpoint)
+	if err != nil {
+		return err
+	}
 	service.Tasks, err = core.NewTaskManager(localEndpoint,
 		time.Duration(config.Service.PollInterval)*time.Millisecond)
 	if err != nil {

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -340,6 +340,8 @@ func statusAsString(statusCode core.TransferStatusCode) string {
 		return "active"
 	case core.TransferStatusInactive:
 		return "inactive"
+	case core.TransferStatusFinalizing:
+		return "finalizing"
 	case core.TransferStatusSucceeded:
 		return "succeeded"
 	case core.TransferStatusFailed:

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -321,7 +321,7 @@ func (service *prototype) createTransfer(w http.ResponseWriter,
 		return
 	}
 
-	taskId, err := service.Tasks.Add(source, destination, request.FileIds)
+	taskId, err := service.Tasks.Add(request.Orcid, source, destination, request.FileIds)
 	if err == nil {
 		jsonData, _ := json.Marshal(TransferResponse{Id: taskId})
 		writeJson(w, jsonData)

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kbase/dts/config"
 	"github.com/kbase/dts/core"
 	"github.com/kbase/dts/databases"
+	"github.com/kbase/dts/endpoints"
 )
 
 // This type implements the TransferService interface, allowing file transfers
@@ -444,7 +445,9 @@ func (service *prototype) Start(port int) error {
 	defer listener.Close()
 	listener = netutil.LimitListener(listener, config.Service.MaxConnections)
 
-	service.Tasks, err = core.NewTaskManager(time.Duration(config.Service.PollInterval) * time.Millisecond)
+	localEndpoint, err := endpoints.NewEndpoint(config.Service.Endpoint)
+	service.Tasks, err = core.NewTaskManager(localEndpoint,
+		time.Duration(config.Service.PollInterval)*time.Millisecond)
 	if err != nil {
 		return err
 	}

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -238,7 +238,7 @@ func breakdown() {
 	if TESTING_DIR != "" {
 		// Remove the testing directory and its contents.
 		log.Printf("Deleting testing directory %s...\n", TESTING_DIR)
-		//		os.RemoveAll(TESTING_DIR)
+		os.RemoveAll(TESTING_DIR)
 	}
 }
 

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -236,7 +236,7 @@ func breakdown() {
 	if TESTING_DIR != "" {
 		// Remove the testing directory and its contents.
 		log.Printf("Deleting testing directory %s...\n", TESTING_DIR)
-		os.RemoveAll(TESTING_DIR)
+		//		os.RemoveAll(TESTING_DIR)
 	}
 }
 
@@ -417,8 +417,14 @@ func TestCreateTransfer(t *testing.T) {
 	assert.Nil(err)
 	assert.True(status.Status == "succeeded")
 
-	// check for the presence of the payload
-	// FIXME
+	// check for the files in the payload
+	// FIXME: the files are written to the destination endpoint's root in a
+	// FIXME: user-specific and task-specific folder. We need to formalize this.
+	username := "user" // FIXME: ???
+	for _, file := range []string{"file1.txt", "file2.txt", "file3.txt", "manifest.json"} {
+		_, err := os.Stat(filepath.Join(destinationRoot, username, xferId.String(), file))
+		assert.Nil(err)
+	}
 }
 
 // attempts to fetch the status of a nonexistent transfer

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -57,6 +57,10 @@ databases:
     organization: Fabulous Destinations, Inc.
     endpoint: destination-endpoint
 endpoints:
+  local-endpoint:
+    name: We need to decide how to support this in testing
+    id: ???
+    provider: globus
   source-endpoint:
     name: Globus Tutorial Endpoint 1
     id: ddb59aef-6d04-11e5-ba46-22000b92c6ec

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -412,7 +412,7 @@ func TestCreateTransfer(t *testing.T) {
 	assert.True(status.Status != "failed")
 
 	// wait a bit for the task to finish (shouldn't take long)
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(600 * time.Millisecond)
 
 	// query the transfer again
 	status, err = queryTransfer()


### PR DESCRIPTION
This PR is larger than I wanted it to be, but I guess we're still in the throes of early development.

Points of interest:

* The DTS now gets its own endpoint, which provides access to its local file system. This is reflected in an updated configuration file format
* The DTS now writes a `manifest.json` file and uses its local endpoint to transfer the manifest to the destination endpoint.
* I've added a "local" endpoint type for testing, since it wasn't clear how to test manifest transfers in CI systems like GitHub Actions. Seems to work!
* Endpoints now have a `Root()` method in their interface, which tells you the root directory of their underlying file system. This turns out to be very helpful.
* I rearranged the logic a bit in the `TaskManager` type, bestowing the lifecycle-related stuff upon a "task" type. I hope the flow of control is a little simpler and more resiliant to concurrent requests.

Work still to do (perhaps in later PRs):

* I've spent almost no time on the contents of the manifest. My concern with this PR was allowing the DTS to write a manifest locally and transfer it to the destination endpoint, which required most of the surgery.
* Files are written to a generic "user" directory with the transfer ID (UUID) as a subdirectory. I don't know what we actually want in practice, so this is just a "rock" for us to start complaining about.
* The example config file in the repo is way out of date at this point. This will start to matter pretty soon.
* There's probably some code cleanup that can be done. A good thing for us to discuss.

Closes #29