### PR TITLE
Implemented preliminary KBase ORCID -> local user federation

### DIFF
--- a/.github/workflows/autotest_prs.yml
+++ b/.github/workflows/autotest_prs.yml
@@ -38,7 +38,13 @@ jobs:
       run: go build -v ./...
 
     - name: Setting up KBase local user federation
-      run: echo "{\"$DTS_KBASE_TEST_ORCID\": \"$DTS_KBASE_TEST_USER\"}" >> kbase_users.json
+      uses: DamianReeves/write-file-action@v1.2
+      with:
+        path: kbase_users.json
+        contents: |
+          {
+            "$DTS_KBASE_TEST_ORCID": "$DTS_KBASE_TEST_USER"
+          }
 
     - name: Testing DTS
       shell: bash

--- a/.github/workflows/autotest_prs.yml
+++ b/.github/workflows/autotest_prs.yml
@@ -38,7 +38,7 @@ jobs:
       run: go build -v ./...
 
     - name: Setting up KBase local user federation
-      run: echo "{\"$DTS_KBASE_TEST_ORCID\": \"$DTS_KBASE_TEST_USER\"}" | fmt > kbase_users.json
+      run: echo "{\"$DTS_KBASE_TEST_ORCID\": \"$DTS_KBASE_TEST_USER\"}" > kbase_users.json
 
     - name: Testing DTS
       shell: bash

--- a/.github/workflows/autotest_prs.yml
+++ b/.github/workflows/autotest_prs.yml
@@ -38,7 +38,7 @@ jobs:
       run: go build -v ./...
 
     - name: Setting up KBase local user federation
-      run: echo "{\"$DTS_KBASE_TEST_ORCID\": \"$DTS_KBASE_TEST_USER\"}" > kbase_users.json
+      run: echo "{\"$DTS_KBASE_TEST_ORCID\": \"$DTS_KBASE_TEST_USER\"}" >> kbase_users.json
 
     - name: Testing DTS
       shell: bash

--- a/.github/workflows/autotest_prs.yml
+++ b/.github/workflows/autotest_prs.yml
@@ -9,6 +9,7 @@ on:
 env:
   DTS_KBASE_DEV_TOKEN: ${{ secrets.DTS_KBASE_DEV_TOKEN }}
   DTS_KBASE_TEST_ORCID: ${{ secrets.DTS_KBASE_TEST_ORCID }}
+  DTS_KBASE_TEST_USER: ${{ secrets.DTS_KBASE_TEST_USER }}
   DTS_GLOBUS_CLIENT_ID: ${{ secrets.DTS_GLOBUS_CLIENT_ID }}
   DTS_GLOBUS_CLIENT_SECRET: ${{ secrets.DTS_GLOBUS_CLIENT_SECRET }}
   DTS_GLOBUS_TEST_ENDPOINT: ${{ secrets.DTS_GLOBUS_TEST_ENDPOINT }}
@@ -35,6 +36,9 @@ jobs:
 
     - name: Building DTS
       run: go build -v ./...
+
+    - name: Setting up KBase local user federation
+      run: echo "{\"$DTS_KBASE_TEST_ORCID\": \"$DTS_KBASE_TEST_USER\"}" | fmt > kbase_users.json
 
     - name: Testing DTS
       shell: bash

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ to do:
 * `DTS_KBASE_TEST_ORCID`: an [ORCID](https://orcid.org/) identifier that can be
   used to run DTS's unit test. This identifier must match a registered ORCID ID
   associated with a [KBase user account](https://narrative.kbase.us/#signup).
+* `DTS_KBASE_TEST_USER`: the KBase user associated with the ORCID specified
+  by `DTS_KBASE_TEST_ORCID`.
 * `DTS_GLOBUS_CLIENT_ID`: a client ID registered using the
   [Globus Developers](https://docs.globus.org/globus-connect-server/v5/use-client-credentials/#register-application)
   web interface. This ID must be registered specifically for an instance of DTS.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ to do:
   specified by `DTS_GLOBUS_CLIENT_ID`
 * `DTS_GLOBUS_TEST_ENDPOINT`: a Globus endpoint used to test DTS's transfer
   capabilities
-
+* `DTS_JDP_SECRET`: a string containing a shared secret that allows the DTS to
+  authenticate with the JGI Data Portal
+* `DTS_ON_LBL_VPN`: set this environment variable to any value (e.g. "1") to
+  indicate that the DTS is running on Lawrence Berkeley Lab's Virtual Private
+  Network. This enables the DTS to get information about files from JAMO that
+  are not available from the JGI Data Portal itself.
 
 

--- a/core/database.go
+++ b/core/database.go
@@ -69,6 +69,6 @@ type Database interface {
 	StagingStatus(id uuid.UUID) (StagingStatus, error)
 	// returns the endpoint associated with this database
 	Endpoint() (Endpoint, error)
-  // returns the local username associated with the given Orcid ID
-  LocalUser(orcid string) (string, error)
+	// returns the local username associated with the given Orcid ID
+	LocalUser(orcid string) (string, error)
 }

--- a/core/database.go
+++ b/core/database.go
@@ -69,4 +69,6 @@ type Database interface {
 	StagingStatus(id uuid.UUID) (StagingStatus, error)
 	// returns the endpoint associated with this database
 	Endpoint() (Endpoint, error)
+  // returns the local username associated with the given Orcid ID
+  LocalUser(orcid string) (string, error)
 }

--- a/core/task_manager.go
+++ b/core/task_manager.go
@@ -52,7 +52,10 @@ type taskType struct {
 // it into disparate pieces makes it any easier to understand, given the state
 // information being managed--that just creates other abstraction problems.
 func (task *taskType) Update() error {
-	username := task.Source.LocalUser(task.Orcid)
+	username, err := task.Source.LocalUser(task.Orcid)
+	if err != nil {
+		return err
+	}
 	sourceEndpoint, err := task.Source.Endpoint()
 	if err != nil {
 		return err

--- a/core/task_manager.go
+++ b/core/task_manager.go
@@ -52,7 +52,7 @@ type taskType struct {
 // it into disparate pieces makes it any easier to understand, given the state
 // information being managed--that just creates other abstraction problems.
 func (task *taskType) Update() error {
-	username := "user" // FIXME: how do we obtain this from our Orcid ID?
+	username := task.Source.LocalUser(task.Orcid)
 	sourceEndpoint, err := task.Source.Endpoint()
 	if err != nil {
 		return err

--- a/core/task_manager_test.go
+++ b/core/task_manager_test.go
@@ -215,6 +215,10 @@ func (db *FakeDatabase) Endpoint() (Endpoint, error) {
 	return db.Endpt, nil
 }
 
+func (db *FakeDatabase) LocalUser(orcid string) (string, error) {
+	return "fakeuser", nil
+}
+
 type TransferInfo struct {
 	Time   time.Time // transfer initiation time
 	Status TransferStatus

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kbase/dts/core"
 	"github.com/kbase/dts/databases/jdp"
+	"github.com/kbase/dts/databases/kbase"
 )
 
 // we maintain a table of database instances, identified by their names
@@ -55,6 +56,7 @@ func NewDatabase(orcid, dbName string) (core.Database, error) {
 	// register our built-in databases if this is the first call to this function
 	if firstNewDatabaseCall {
 		RegisterDatabase("jdp", jdp.NewDatabase)
+		RegisterDatabase("kbase", kbase.NewDatabase)
 		firstNewDatabaseCall = false
 	}
 

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -537,6 +537,6 @@ func (db *Database) Endpoint() (core.Endpoint, error) {
 }
 
 func (db *Database) LocalUser(orcid string) (string, error) {
-  // no current mechanism for this
-  return "localuser"
+	// no current mechanism for this
+	return "localuser", nil
 }

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -535,3 +535,8 @@ func (db *Database) StagingStatus(id uuid.UUID) (core.StagingStatus, error) {
 func (db *Database) Endpoint() (core.Endpoint, error) {
 	return endpoints.NewEndpoint(config.Databases[db.Id].Endpoint)
 }
+
+func (db *Database) LocalUser(orcid string) (string, error) {
+  // no current mechanism for this
+  return "localuser"
+}

--- a/databases/jdp/database_test.go
+++ b/databases/jdp/database_test.go
@@ -1,6 +1,7 @@
 package jdp
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 
@@ -32,6 +33,8 @@ endpoints:
 
 // this function gets called at the begіnning of a test session
 func setup() {
+	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelDebug)
 	config.Init([]byte(jdpConfig))
 }
 

--- a/databases/jdp/jamo.go
+++ b/databases/jdp/jamo.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
@@ -83,8 +84,10 @@ func queryJamo(fileIds []string) ([]jamoFileRecord, error) {
 	// for fetching file paths, and since JAMO only works within LBL's VPN)
 	var recordingMode recorder.Mode
 	if _, onVPN := os.LookupEnv("DTS_ON_LBL_VPN"); onVPN {
-		recordingMode = recorder.ModeRecordOnly
+		slog.Debug("Querying JAMO for file resource info")
+		recordingMode = recorder.ModeRecordOnce
 	} else {
+		slog.Debug("Using pre-recorded JAMO results for query")
 		recordingMode = recorder.ModeReplayOnly
 	}
 	r, err := recorder.NewWithOptions(&recorder.Options{

--- a/databases/jdp/jamo.go
+++ b/databases/jdp/jamo.go
@@ -85,7 +85,7 @@ func queryJamo(fileIds []string) ([]jamoFileRecord, error) {
 	var recordingMode recorder.Mode
 	if _, onVPN := os.LookupEnv("DTS_ON_LBL_VPN"); onVPN {
 		slog.Debug("Querying JAMO for file resource info")
-		recordingMode = recorder.ModeRecordOnce
+		recordingMode = recorder.ModeRecordOnly
 	} else {
 		slog.Debug("Using pre-recorded JAMO results for query")
 		recordingMode = recorder.ModeReplayOnly

--- a/databases/kbase/database.go
+++ b/databases/kbase/database.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package kbase
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/kbase/dts/config"
+	"github.com/kbase/dts/core"
+	"github.com/kbase/dts/endpoints"
+)
+
+// file database appropriate for handling KBase searches and transfers
+// (implements the core.Database interface)
+type Database struct {
+	// database identifier
+	Id string
+}
+
+func NewDatabase(orcid string) (core.Database, error) {
+	if orcid == "" {
+		return nil, fmt.Errorf("No ORCID ID was given")
+	}
+
+	return &Database{
+		Id: "kbase",
+	}, nil
+}
+
+func (db *Database) Search(params core.SearchParameters) (core.SearchResults, error) {
+	err := fmt.Errorf("Search not implemented for kbase database!")
+	return core.SearchResults{}, err
+}
+
+func (db *Database) Resources(fileIds []string) ([]core.DataResource, error) {
+	err := fmt.Errorf("Resources not implemented for kbase database!")
+	return nil, err
+}
+
+func (db *Database) StageFiles(fileIds []string) (uuid.UUID, error) {
+	err := fmt.Errorf("StageFiles not implemented for kbase database!")
+	return uuid.UUID{}, err
+}
+
+func (db *Database) StagingStatus(id uuid.UUID) (core.StagingStatus, error) {
+	err := fmt.Errorf("StagingStatus not implemented for kbase database!")
+	return core.StagingStatusUnknown, err
+}
+
+func (db *Database) Endpoint() (core.Endpoint, error) {
+	return endpoints.NewEndpoint(config.Databases[db.Id].Endpoint)
+}
+
+func (db *Database) LocalUser(orcid string) (string, error) {
+	// no current mechanism for this
+	return "localuser", nil
+}

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -191,7 +190,6 @@ func (ep *Endpoint) get(resource string, values url.Values) (*http.Response, err
 		u.Path = fmt.Sprintf("%s/%s", globusTransferApiVersion, resource)
 		u.RawQuery = values.Encode()
 		res := fmt.Sprintf("%v", u)
-		log.Printf("GET: %s", res)
 		req, err := http.NewRequest(http.MethodGet, res, http.NoBody)
 		if err == nil {
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", ep.AccessToken))
@@ -208,7 +206,6 @@ func (ep *Endpoint) post(resource string, body io.Reader) (*http.Response, error
 	if err == nil {
 		u.Path = fmt.Sprintf("%s/%s", globusTransferApiVersion, resource)
 		res := fmt.Sprintf("%v", u)
-		log.Printf("POST: %s", res)
 		var req *http.Request
 		req, err = http.NewRequest(http.MethodPost, res, body)
 		if err == nil {

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -40,6 +40,7 @@ var (
 	apiPrefix = "api/v1/"
 )
 
+var testUser string = "testuser"
 var sourceRoot string
 var destinationRoot string
 
@@ -156,6 +157,10 @@ func (db *testDatabase) StagingStatus(stagingId uuid.UUID) (core.StagingStatus, 
 
 func (db *testDatabase) Endpoint() (core.Endpoint, error) {
 	return db.endpoint, nil
+}
+
+func (db *testDatabase) LocalUser(orcid string) (string, error) {
+	return testUser, nil
 }
 
 // performs testing setup
@@ -422,7 +427,7 @@ func TestCreateTransfer(t *testing.T) {
 	// check for the files in the payload
 	// FIXME: the files are written to the destination endpoint's root in a
 	// FIXME: user-specific and task-specific folder. We need to formalize this.
-	username := "user" // FIXME: ???
+	username := testUser
 	for _, file := range []string{"file1.txt", "file2.txt", "file3.txt", "manifest.json"} {
 		_, err := os.Stat(filepath.Join(destinationRoot, username, xferId.String(), file))
 		assert.Nil(err)


### PR DESCRIPTION
This PR adds a mechanism for mapping ORCID IDs to local KBase users for our end-to-end demo. This is accomplished by assuming the existence of a `kbase_users.json` file in the current working directory for the DTS. The JSON file contains a single object whose fields are ORCIDs with string values containing associated local usernames. There's also a bit of logging cleanup.

This should be merged after #32.