### PR TITLE
Reinstating Globus test endpoint that uses LBNL's Google Drive collection

### DIFF
--- a/endpoints/globus/endpoint_test.go
+++ b/endpoints/globus/endpoint_test.go
@@ -275,10 +275,8 @@ func TestGlobusTransferCancellation(t *testing.T) {
 // this runs setup, runs all tests, and does breakdown
 func TestMain(m *testing.M) {
 	var status int
-	//setup()
-	//status = m.Run()
-	//breakdown()
-	fmt.Printf("Skipping Globus endpoints tests because LBNL's Google Drive connector is down!")
-	status = 0
+	setup()
+	status = m.Run()
+	breakdown()
 	os.Exit(status)
 }


### PR DESCRIPTION
I noticed this morning that LBNL's Globus Google Drive connector is working again, so I'm reinstating the tests that use it. We still need a more permanent solution (see #68), but we've got enough stuff going on now that it probably makes sense to circle back to this a bit later.