### PR TITLE
Added an endpoint allowing file metadata to be requested by ID.

### DIFF
--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -416,6 +416,35 @@ func TestSearchDatabase(t *testing.T) {
 	assert.Equal("file1", results.Resources[0].Name)
 }
 
+// fetches file metadata from the JDP for some specific files
+func TestFetchJdpMetadata(t *testing.T) {
+	assert := assert.New(t)
+
+	// try omitting file IDs
+	resp, err := get(baseUrl + apiPrefix + "files/by-id?database=jdp")
+	assert.Nil(err)
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	// now let's fetch 3 records
+	resp, err = get(baseUrl + apiPrefix +
+		"files/by-id?database=jdp&ids=JDP:6101cc0f2b1f2eeea564c978,JDP:613a7baa72d3a08c9a54b32d,JDP:61412246cc4ff44f36c8913d")
+	assert.Nil(err)
+
+	respBody, err := io.ReadAll(resp.Body)
+	assert.Nil(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+
+	var results SearchResultsResponse
+	err = json.Unmarshal(respBody, &results)
+	assert.Nil(err)
+	assert.Equal("jdp", results.Database)
+	assert.Equal(3, len(results.Resources))
+	assert.Equal("JDP:6101cc0f2b1f2eeea564c978", results.Resources[0].Id)
+	assert.Equal("JDP:613a7baa72d3a08c9a54b32d", results.Resources[1].Id)
+	assert.Equal("JDP:61412246cc4ff44f36c8913d", results.Resources[2].Id)
+}
+
 // creates a transfer from source -> destination1
 func TestCreateTransfer(t *testing.T) {
 	assert := assert.New(t)

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -2,23 +2,11 @@ package services
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 
 	"github.com/google/uuid"
 
 	"github.com/kbase/dts/frictionless"
 )
-
-// This package-specific helper function writes a JSON payload to an
-// http.ResponseWriter.
-func writeJson(w http.ResponseWriter, data []byte, code int) {
-	w.WriteHeader(code)
-	if len(data) > 0 {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(data)
-	}
-}
 
 // this type encodes a JSON object for responding to root queries
 type ServiceInfoResponse struct {
@@ -37,17 +25,6 @@ type ErrorResponse struct {
 	Error string `json:"message"`
 }
 
-// This package-specific helper function writes an error to an
-// http.ResponseWriter, giving it the proper status code, and encoding an
-// ErrorResponse in the response body.
-func writeError(w http.ResponseWriter, message string, code int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	e := ErrorResponse{Code: code, Error: message}
-	data, _ := json.Marshal(e)
-	w.Write(data)
-}
-
 // a response for a database-related query (GET)
 type DatabaseResponse struct {
 	Id           string `json:"id" example:"jdp" `
@@ -56,13 +33,21 @@ type DatabaseResponse struct {
 	URL          string `json:"url" example:"https://data.jgi.doe.gov"`
 }
 
-// a response for a query (GET)
+// a response for a file search query (GET)
 type SearchResultsResponse struct {
 	// name of organization database
 	Database string `json:"database" example:"jdp" doc:"the database searched"`
 	// ElasticSearch query string
 	Query string `json:"query" example:"prochlorococcus" doc:"the given query string"`
-	// Resources matching the query
+	// resources matching the query
+	Resources []frictionless.DataResource `json:"resources" doc:"an array of Frictionless DataResources"`
+}
+
+// a response for a file metadata query (GET)
+type FileMetadataResponse struct {
+	// name of organization database
+	Database string `json:"database" example:"jdp" doc:"the database searched"`
+	// resources corresponding to given file IDs
 	Resources []frictionless.DataResource `json:"resources" doc:"an array of Frictionless DataResources"`
 }
 


### PR DESCRIPTION
This change adds a new DTS endpoint that allows file metadata to be retrieved by ID, similar to the new JDP endpoint. Since all databases must support this functionality, this is just a database-neutral file metadata endpoint that we can use to fetch missing metadata whenever it's needed.

I'll create a corresponding method for `dtspy` for this new endpoint.

This should go in after #75 