### PR TITLE
Filling some gaps in the DTS manifest

### DIFF
--- a/auth/kbase_auth_server_test.go
+++ b/auth/kbase_auth_server_test.go
@@ -44,27 +44,21 @@ func TestNewKBaseAuthServer(t *testing.T) {
 	assert.Nil(err, "Authentication server constructor triggered an error")
 }
 
-// tests whether the authentication server can return the username for the
-// for the owner of the developer token
-func TestUsername(t *testing.T) {
+// tests whether the authentication server can return information for the
+// user associated with the specified developer token
+func TestUserInfo(t *testing.T) {
 	assert := assert.New(t)
 	devToken := os.Getenv("DTS_KBASE_DEV_TOKEN")
 	server, _ := NewKBaseAuthServer(devToken)
 	assert.NotNil(server)
-	username, err := server.Username()
+	userInfo, err := server.UserInfo()
 	assert.Nil(err)
-	assert.True(len(username) > 0)
-}
 
-// tests whether the authentication server can return the proper credentials
-// for the owner of the developer token
-func TestOrchids(t *testing.T) {
-	assert := assert.New(t)
-	devToken := os.Getenv("DTS_KBASE_DEV_TOKEN")
+	assert.True(len(userInfo.Username) > 0)
+	assert.True(len(userInfo.Email) > 0)
+
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	assert.False(orcid == "")
-	server, _ := NewKBaseAuthServer(devToken)
-	orcids, err := server.Orcids()
+	orcids, err := userInfo.Orcids()
 	assert.Nil(err)
 	var foundOrcid bool
 	for _, id := range orcids {

--- a/auth/kbase_auth_server_test.go
+++ b/auth/kbase_auth_server_test.go
@@ -44,6 +44,16 @@ func TestNewKBaseAuthServer(t *testing.T) {
 	assert.Nil(err, "Authentication server constructor triggered an error")
 }
 
+// tests whether an invalid KBase token prevents a proxy for the auth server
+// from being constructed
+func TestInvalidToken(t *testing.T) {
+	assert := assert.New(t)
+	devToken := "INVALID_KBASE_TOKEN"
+	server, err := NewKBaseAuthServer(devToken)
+	assert.Nil(server, "Authentication server created with invalid token")
+	assert.NotNil(err, "Invalid token for authentication server triggered no error")
+}
+
 // tests whether the authentication server can return information for the
 // user associated with the specified developer token
 func TestUserInfo(t *testing.T) {

--- a/auth/kbase_auth_server_test.go
+++ b/auth/kbase_auth_server_test.go
@@ -56,16 +56,5 @@ func TestUserInfo(t *testing.T) {
 
 	assert.True(len(userInfo.Username) > 0)
 	assert.True(len(userInfo.Email) > 0)
-
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	orcids, err := userInfo.Orcids()
-	assert.Nil(err)
-	var foundOrcid bool
-	for _, id := range orcids {
-		if orcid == id {
-			foundOrcid = true
-			break
-		}
-	}
-	assert.True(foundOrcid)
+	assert.Equal(os.Getenv("DTS_KBASE_TEST_ORCID"), userInfo.Orcid)
 }

--- a/auth/user_info.go
+++ b/auth/user_info.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package auth
+
+// a record containing information about a DTS user
+type UserInfo struct {
+	// user's name (human-readable and display-friendly)
+	Name string
+	// username used to access DTS
+	Username string
+	// user's email address
+	Email string
+	// ORCID identifier associated with this user
+	Orcid string
+	// organization with which this user is affiliated
+	Organization string
+}

--- a/frictionless/frictionless.go
+++ b/frictionless/frictionless.go
@@ -61,6 +61,8 @@ type DataPackage struct {
 	Contributors []Contributor `json:"contributors,omitempty"`
 	// an image to use for this data package (URL or POSIX path)
 	Image string `json:"image,omitempty"`
+	// a machine-readable set of instructions for processing
+	Instructions json.RawMessage `json:"instructions,omitempty"`
 }
 
 // a Frictionless data resource describing a file in a search

--- a/frictionless/frictionless.go
+++ b/frictionless/frictionless.go
@@ -40,6 +40,27 @@ type DataPackage struct {
 	Licenses []DataLicense `json:"licenses,omitempty"`
 	// a list identifying the sources for this resource (optional)
 	Sources []DataSource `json:"sources,omitempty"`
+	// a timestamp indicated when the package was created
+	Created string `json:"created,omitempty"`
+	// the profile of this descriptor per the DataPackage profiles specification
+	// (https://specs.frictionlessdata.io/profiles/#language)
+	Profile string `json:"profile,omitempty"`
+	// a title or one sentence description for the data package
+	Title string `json:"title,omitempty"`
+	// a Markdown description of the data package
+	Description string `json:"description,omitempty"`
+	// a URL for a web address related to the data package
+	Homepage string `json:"homepage,omitempty"`
+	// a version string identifying the version of the data package, conforming to
+	// semantic versioning if relevant
+	Version string `json:"version,omitempty"`
+	// an array of string keywords to assist users searching for the data package
+	// in catalogs
+	Keywords []string `json:"keywords,omitempty"`
+	// list of contributors to the data package
+	Contributors []Contributor `json:"contributors,omitempty"`
+	// an image to use for this data package (URL or POSIX path)
+	Image string `json:"image,omitempty"`
 }
 
 // a Frictionless data resource describing a file in a search
@@ -106,4 +127,20 @@ type DataLicense struct {
 	Path string `json:"path"`
 	// the descriptive title of the license (optional)
 	Title string `json:"title,omitempty"`
+}
+
+// information about a contributor to a DataPackage
+type Contributor struct {
+	// name/title of the contributor (name for person, name/title of organization)
+	Title string `json:"title"`
+	// the contributor's email address
+	Email string `json:"email"`
+	// a fully qualified http URL pointing to a relevant location online for the
+	// contributor
+	Path string `json:"path"`
+	// the role of the contributor ("author", "publisher", "maintainer",
+	// "wrangler", "contributor")
+	Role string `json:"role"`
+	// a string describing the contributor's organization
+	Organization string `json:"organization"`
 }

--- a/frictionless/frictionless.go
+++ b/frictionless/frictionless.go
@@ -31,73 +31,73 @@ import (
 // a Frictionless data package describing a set of related resources
 // (https://specs.frictionlessdata.io/data-package/)
 type DataPackage struct {
-	// the name of the data package
-	Name string `json:"name"`
-	// a list of resources that belong to the package
-	Resources []DataResource `json:"resources"`
-	// a list identifying the license or licenses under which this resource is
-	// managed (optional)
-	Licenses []DataLicense `json:"licenses,omitempty"`
-	// a list identifying the sources for this resource (optional)
-	Sources []DataSource `json:"sources,omitempty"`
+	// list of contributors to the data package
+	Contributors []Contributor `json:"contributors,omitempty"`
 	// a timestamp indicated when the package was created
 	Created string `json:"created,omitempty"`
-	// the profile of this descriptor per the DataPackage profiles specification
-	// (https://specs.frictionlessdata.io/profiles/#language)
-	Profile string `json:"profile,omitempty"`
-	// a title or one sentence description for the data package
-	Title string `json:"title,omitempty"`
 	// a Markdown description of the data package
 	Description string `json:"description,omitempty"`
 	// a URL for a web address related to the data package
 	Homepage string `json:"homepage,omitempty"`
-	// a version string identifying the version of the data package, conforming to
-	// semantic versioning if relevant
-	Version string `json:"version,omitempty"`
-	// an array of string keywords to assist users searching for the data package
-	// in catalogs
-	Keywords []string `json:"keywords,omitempty"`
-	// list of contributors to the data package
-	Contributors []Contributor `json:"contributors,omitempty"`
 	// an image to use for this data package (URL or POSIX path)
 	Image string `json:"image,omitempty"`
 	// a machine-readable set of instructions for processing
 	Instructions json.RawMessage `json:"instructions,omitempty"`
+	// an array of string keywords to assist users searching for the data package
+	// in catalogs
+	Keywords []string `json:"keywords,omitempty"`
+	// a list identifying the license or licenses under which this resource is
+	// managed (optional)
+	Licenses []DataLicense `json:"licenses,omitempty"`
+	// the name of the data package
+	Name string `json:"name"`
+	// the profile of this descriptor per the DataPackage profiles specification
+	// (https://specs.frictionlessdata.io/profiles/#language)
+	Profile string `json:"profile,omitempty"`
+	// a list of resources that belong to the package
+	Resources []DataResource `json:"resources"`
+	// a list identifying the sources for this resource (optional)
+	Sources []DataSource `json:"sources,omitempty"`
+	// a title or one sentence description for the data package
+	Title string `json:"title,omitempty"`
+	// a version string identifying the version of the data package, conforming to
+	// semantic versioning if relevant
+	Version string `json:"version,omitempty"`
 }
 
 // a Frictionless data resource describing a file in a search
 // (https://specs.frictionlessdata.io/data-resource/)
 type DataResource struct {
+	// the size of the resource's file in bytes
+	Bytes int `json:"bytes"`
+	// credit metadata associated with the resource (optional for now)
+	Credit credit.CreditMetadata `json:"credit,omitempty"`
+	// a description of the resource (optional)
+	Description string `json:"description,omitempty"`
+	// the character encoding for the resource's file (optional, default: UTF-8)
+	Encoding string `json:"encoding,omitempty"`
+	// any other fields requested e.g. by a search query (optional, raw JSON object)
+	Extra json.RawMessage `json:"extra,omitempty"`
+	// indicates the format of the resource's file, often used as an extension
+	Format string `json:"format"`
+	// the hash for the resource's file (algorithms other than MD5 are indicated
+	// with a prefix to the hash delimited by a colon)
+	Hash string `json:"hash"`
 	// a unique identifier for the resource
 	Id string `json:"id"`
+	// a list identifying the license or licenses under which this resource is
+	// managed (optional)
+	Licenses []DataLicense `json:"licenses,omitempty"`
+	// the mediatype/mimetype of the resource (optional, e.g. "test/csv")
+	MediaType string `json:"media_type,omitempty"`
 	// the name of the resource's file, with any suffix stripped off
 	Name string `json:"name"`
 	// a relative path to the resource's file within a data package directory
 	Path string `json:"path"`
-	// a title or label for the resource (optional)
-	Title string `json:"title,omitempty"`
-	// a description of the resource (optional)
-	Description string `json:"description,omitempty"`
-	// indicates the format of the resource's file, often used as an extension
-	Format string `json:"format"`
-	// the mediatype/mimetype of the resource (optional, e.g. "test/csv")
-	MediaType string `json:"media_type,omitempty"`
-	// the character encoding for the resource's file (optional, default: UTF-8)
-	Encoding string `json:"encoding,omitempty"`
-	// the size of the resource's file in bytes
-	Bytes int `json:"bytes"`
-	// the hash for the resource's file (algorithms other than MD5 are indicated
-	// with a prefix to the hash delimited by a colon)
-	Hash string `json:"hash"`
 	// a list identifying the sources for this resource (optional)
 	Sources []DataSource `json:"sources,omitempty"`
-	// a list identifying the license or licenses under which this resource is
-	// managed (optional)
-	Licenses []DataLicense `json:"licenses,omitempty"`
-	// credit metadata associated with the resource (optional for now)
-	Credit credit.CreditMetadata `json:"credit,omitempty"`
-	// any other fields requested e.g. by a search query (optional, raw JSON object)
-	Extra json.RawMessage `json:"extra,omitempty"`
+	// a title or label for the resource (optional)
+	Title string `json:"title,omitempty"`
 }
 
 // call this to get a string containing the name of the hashing algorithm used
@@ -113,12 +113,12 @@ func (res DataResource) HashAlgorithm() string {
 
 // information about the source of a DataResource
 type DataSource struct {
-	// a descriptive title for the source
-	Title string `json:"title"`
-	// a URI or relative path pointing to the source (optional)
-	Path string `json:"path,omitempty"`
 	// an email address identifying a contact associated with the source (optional)
 	Email string `json:"email,omitempty"`
+	// a URI or relative path pointing to the source (optional)
+	Path string `json:"path,omitempty"`
+	// a descriptive title for the source
+	Title string `json:"title"`
 }
 
 // information about a license associated with a DataResource
@@ -133,16 +133,16 @@ type DataLicense struct {
 
 // information about a contributor to a DataPackage
 type Contributor struct {
-	// name/title of the contributor (name for person, name/title of organization)
-	Title string `json:"title"`
 	// the contributor's email address
 	Email string `json:"email"`
+	// a string describing the contributor's organization
+	Organization string `json:"organization"`
 	// a fully qualified http URL pointing to a relevant location online for the
 	// contributor
 	Path string `json:"path"`
 	// the role of the contributor ("author", "publisher", "maintainer",
 	// "wrangler", "contributor")
 	Role string `json:"role"`
-	// a string describing the contributor's organization
-	Organization string `json:"organization"`
+	// name/title of the contributor (name for person, name/title of organization)
+	Title string `json:"title"`
 }

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -456,11 +456,12 @@ func (service *prototype) createTransfer(ctx context.Context,
 	}
 
 	taskId, err := tasks.Create(tasks.Specification{
-		UserInfo:    userInfo,
-		Source:      input.Body.Source,
-		Destination: input.Body.Destination,
-		FileIds:     input.Body.FileIds,
-		Description: input.Body.Description,
+		UserInfo:     userInfo,
+		Source:       input.Body.Source,
+		Destination:  input.Body.Destination,
+		FileIds:      input.Body.FileIds,
+		Description:  input.Body.Description,
+		Instructions: input.Body.Instructions,
 	})
 	if err != nil {
 		return nil, err

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -458,8 +458,13 @@ func (service *prototype) createTransfer(ctx context.Context,
 		return nil, err
 	}
 
-	taskId, err := tasks.Create(orcid, input.Body.Source,
-		input.Body.Destination, input.Body.FileIds)
+	taskId, err := tasks.Create(tasks.Specification{
+		Orcid:       orcid,
+		Source:      input.Body.Source,
+		Destination: input.Body.Destination,
+		FileIds:     input.Body.FileIds,
+		Description: input.Body.Description,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -54,8 +54,9 @@ type prototype struct {
 	Server *http.Server
 }
 
-// authorize clients for the DTS, returning the client's ORCID ID and an error
-// describing any issue encountered
+// authorize clients for the DTS, returning information about the user
+// corresponding to the token in the header (or an error describing any issue
+// encountered)
 func authorize(authorizationHeader string) (auth.UserInfo, error) {
 	if !strings.Contains(authorizationHeader, "Bearer") {
 		return auth.UserInfo{}, fmt.Errorf("Invalid authorization header")
@@ -68,7 +69,7 @@ func authorize(authorizationHeader string) (auth.UserInfo, error) {
 	accessToken := strings.TrimSpace(string(accessTokenBytes))
 
 	// check the access token against the KBase auth server
-	// and fetch the first ORCID associated with it
+	// and return info about the corresponding user
 	authServer, err := auth.NewKBaseAuthServer(accessToken)
 	if err != nil {
 		return auth.UserInfo{}, huma.Error401Unauthorized(err.Error())
@@ -77,7 +78,7 @@ func authorize(authorizationHeader string) (auth.UserInfo, error) {
 	if err != nil {
 		return userInfo, huma.Error401Unauthorized(err.Error())
 	}
-	return userInfo, nil // return the first ORCID encountered
+	return userInfo, nil
 }
 
 type ServiceInfoOutput struct {

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -70,18 +70,15 @@ func authorize(authorizationHeader string) (string, error) {
 	// check the access token against the KBase auth server
 	// and fetch the first ORCID associated with it
 	authServer, err := auth.NewKBaseAuthServer(accessToken)
-	var orcid string
-	var orcids []string
-	if err == nil {
-		orcids, err = authServer.Orcids()
-		if err == nil {
-			orcid = orcids[0]
-		}
-	}
 	if err != nil {
-		return orcid, huma.Error401Unauthorized(err.Error())
+		return "", huma.Error401Unauthorized(err.Error())
 	}
-	return orcid, nil
+	userInfo, err := authServer.UserInfo()
+	orcids, err := userInfo.Orcids()
+	if err != nil {
+		return "", huma.Error401Unauthorized(err.Error())
+	}
+	return orcids[0], nil // return the first ORCID encountered
 }
 
 type ServiceInfoOutput struct {

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/google/uuid"
 
@@ -59,9 +60,10 @@ type TransferRequest struct {
 	FileIds []string `json:"file_ids" example:"[\"fileid1\", \"fileid2\"]" doc:"source-specific identifiers for files to be transferred"`
 	// name of destination database
 	Destination string `json:"destination" example:"kbase" doc:"destination database identifier"`
-	// a Markdown description of the transfer request (can contain e.g. machine-
-	// readable instructions for processing a payload at the desination site)
-	Description string `json:"description" example:"# title\n* type: assembly\n" doc:"Markdown task description, possibly with machine-readable instructions for processing payload at destination"`
+	// a Markdown description of the transfer request
+	Description string `json:"description" example:"# title\n* type: assembly\n" doc:"Markdown task description"`
+	// machine-readable instructions for processing a payload at the destination site
+	Instructions json.RawMessage `json:"instructions" doc:"JSON object containing machine-readable instructions for processing payload at destination"`
 }
 
 // a response for a file transfer request (POST)

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -61,9 +61,9 @@ type TransferRequest struct {
 	// name of destination database
 	Destination string `json:"destination" example:"kbase" doc:"destination database identifier"`
 	// a Markdown description of the transfer request
-	Description string `json:"description" example:"# title\n* type: assembly\n" doc:"Markdown task description"`
+	Description string `json:"description,omitempty" example:"# title\n* type: assembly\n" doc:"Markdown task description"`
 	// machine-readable instructions for processing a payload at the destination site
-	Instructions json.RawMessage `json:"instructions" doc:"JSON object containing machine-readable instructions for processing payload at destination"`
+	Instructions json.RawMessage `json:"instructions,omitempty" doc:"JSON object containing machine-readable instructions for processing payload at destination"`
 }
 
 // a response for a file transfer request (POST)

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -59,6 +59,9 @@ type TransferRequest struct {
 	FileIds []string `json:"file_ids" example:"[\"fileid1\", \"fileid2\"]" doc:"source-specific identifiers for files to be transferred"`
 	// name of destination database
 	Destination string `json:"destination" example:"kbase" doc:"destination database identifier"`
+	// a Markdown description of the transfer request (can contain e.g. machine-
+	// readable instructions for processing a payload at the desination site)
+	Description string `json:"description" example:"# title\n* type: assembly\n" doc:"Markdown task description, possibly with machine-readable instructions for processing payload at destination"`
 }
 
 // a response for a file transfer request (POST)

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -67,41 +67,43 @@ const (
 
 // this type holds a specification used to create a valid transfer task
 type Specification struct {
-	// information about the user requesting the task
-	UserInfo auth.UserInfo
-	// the name of source database from which files are transferred (as specified
-	// in the DTS config file)
-	Source string
+	// a Markdown description of the transfer task
+	Description string
 	// the name of destination database from which files are transferred (as
 	// specified in the DTS config file)
 	Destination string
+	// machine-readable instructions for processing the payload at its destination
+	Instructions json.RawMessage
 	// an array of identifiers for files to be transferred from Source to
 	// Destination
 	FileIds []string
-	// a Markdown description of the transfer task
-	Description string
-	// machine-readable instructions for processing the payload at its destination
-	Instructions json.RawMessage
+	// the name of source database from which files are transferred (as specified
+	// in the DTS config file)
+	Source string
+	// information about the user requesting the task
+	UserInfo auth.UserInfo
 }
 
 // this type holds multiple (possibly null) UUIDs corresponding to different
 // states in the file transfer lifecycle
 type taskType struct {
-	Id                  uuid.UUID       // task identifier
-	DestinationFolder   string          // folder path to which files are transferred
-	UserInfo            auth.UserInfo   // info about user requesting transfer
-	Source, Destination string          // names of source and destination databases
-	FileIds             []string        // IDs of files within Source
-	Description         string          // Markdown description of the task
-	Instructions        json.RawMessage // machine-readable task processing instructions
-	Resources           []DataResource  // Frictionless DataResources for files
-	PayloadSize         float64         // Size of payload (gigabytes)
-	Canceled            bool            // set if a cancellation request has been made
-	Staging, Transfer   uuid.NullUUID   // staging and file transfer UUIDs (if any)
-	Manifest            uuid.NullUUID   // manifest generation UUID (if any)
-	ManifestFile        string          // name of locally-created manifest file
-	Status              TransferStatus  // status of file transfer operation
-	CompletionTime      time.Time       // time at which the transfer completed
+	Canceled          bool            // set if a cancellation request has been made
+	CompletionTime    time.Time       // time at which the transfer completed
+	Description       string          // Markdown description of the task
+	Destination       string          // name of destination database
+	DestinationFolder string          // folder path to which files are transferred
+	FileIds           []string        // IDs of files within Source
+	Id                uuid.UUID       // task identifier
+	Instructions      json.RawMessage // machine-readable task processing instructions
+	Manifest          uuid.NullUUID   // manifest generation UUID (if any)
+	ManifestFile      string          // name of locally-created manifest file
+	PayloadSize       float64         // Size of payload (gigabytes)
+	Resources         []DataResource  // Frictionless DataResources for files
+	Source            string          // name of source database
+	Staging           uuid.NullUUID   // staging UUID (if any)
+	Status            TransferStatus  // status of file transfer operation
+	Transfer          uuid.NullUUID   // file transfer UUID (if any)
+	UserInfo          auth.UserInfo   // info about user requesting transfer
 }
 
 // This error type is returned when a payload is requested that is too large.

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kbase/dts/auth"
 	"github.com/kbase/dts/config"
 	"github.com/kbase/dts/dtstest"
 )
@@ -178,9 +179,11 @@ func (t *SerialTests) TestCreateTask() {
 	deleteAfter := time.Duration(config.Service.DeleteAfter) * time.Second
 
 	// queue up a transfer task between two phony databases
-	orcid := "1234-5678-9012-3456"
 	taskId, err := Create(Specification{
-		Orcid:       orcid,
+		UserInfo: auth.UserInfo{
+			Name:  "Joe-bob",
+			Orcid: "1234-5678-9012-3456",
+		},
 		Source:      "test-source",
 		Destination: "test-destination",
 		FileIds:     []string{"file1", "file2"},
@@ -240,7 +243,10 @@ func (t *SerialTests) TestCancelTask() {
 
 	// queue up a transfer task between two phony databases
 	taskId, err := Create(Specification{
-		Orcid:       "1234-5678-9012-3456",
+		UserInfo: auth.UserInfo{
+			Name:  "Joe-bob",
+			Orcid: "1234-5678-9012-3456",
+		},
 		Source:      "test-source",
 		Destination: "test-destination",
 		FileIds:     []string{"file1", "file2"},
@@ -283,7 +289,10 @@ func (t *SerialTests) TestStopAndRestart() {
 	taskIds := make([]uuid.UUID, numTasks)
 	for i := 0; i < numTasks; i++ {
 		taskId, _ := Create(Specification{
-			Orcid:       "1234-5678-9012-3456",
+			UserInfo: auth.UserInfo{
+				Name:  "Joe-bob",
+				Orcid: "1234-5678-9012-3456",
+			},
 			Source:      "test-source",
 			Destination: "test-destination",
 			FileIds:     []string{"file1", "file2"},

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -179,7 +179,12 @@ func (t *SerialTests) TestCreateTask() {
 
 	// queue up a transfer task between two phony databases
 	orcid := "1234-5678-9012-3456"
-	taskId, err := Create(orcid, "test-source", "test-destination", []string{"file1", "file2"})
+	taskId, err := Create(Specification{
+		Orcid:       orcid,
+		Source:      "test-source",
+		Destination: "test-destination",
+		FileIds:     []string{"file1", "file2"},
+	})
 	assert.Nil(err)
 	assert.True(taskId != uuid.UUID{})
 
@@ -234,8 +239,12 @@ func (t *SerialTests) TestCancelTask() {
 	pollInterval := time.Duration(config.Service.PollInterval) * time.Millisecond
 
 	// queue up a transfer task between two phony databases
-	orcid := "1234-5678-9012-3456"
-	taskId, err := Create(orcid, "test-source", "test-destination", []string{"file1", "file2"})
+	taskId, err := Create(Specification{
+		Orcid:       "1234-5678-9012-3456",
+		Source:      "test-source",
+		Destination: "test-destination",
+		FileIds:     []string{"file1", "file2"},
+	})
 	assert.Nil(err)
 	assert.True(taskId != uuid.UUID{})
 
@@ -270,11 +279,15 @@ func (t *SerialTests) TestStopAndRestart() {
 	// start up, add a bunch of tasks, then immediately close
 	err := Start()
 	assert.Nil(err)
-	orcid := "1234-5678-9012-3456"
 	numTasks := 10
 	taskIds := make([]uuid.UUID, numTasks)
 	for i := 0; i < numTasks; i++ {
-		taskId, _ := Create(orcid, "test-source", "test-destination", []string{"file1", "file2"})
+		taskId, _ := Create(Specification{
+			Orcid:       "1234-5678-9012-3456",
+			Source:      "test-source",
+			Destination: "test-destination",
+			FileIds:     []string{"file1", "file2"},
+		})
 		taskIds[i] = taskId
 	}
 	time.Sleep(100 * time.Millisecond) // let things settle


### PR DESCRIPTION
This set of changes adds several fields to our frictionless DataPackage format, in service of providing information that is helpful for the destination database in processing payloads. It also gathers user metadata into a single simple type within the `auth` package and propagates the information for the user requesting a transfer into the transfer process.

This should go in after #76.