### PR TITLE
Embedding transfer ID in the generated manifest filename (because we can).

### DIFF
--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -330,9 +330,9 @@ func (task *taskType) checkTransfer() error {
 			if err != nil {
 				return fmt.Errorf("marshalling manifest content: %s", err.Error())
 			}
-			var manifestFile *os.File
-			manifestFile, err = os.CreateTemp(config.Service.ManifestDirectory,
-				"manifest.json")
+			task.ManifestFile = filepath.Join(config.Service.ManifestDirectory,
+				fmt.Sprintf("manifest-%s.json", task.Id.String()))
+			manifestFile, err := os.Create(task.ManifestFile)
 			if err != nil {
 				return fmt.Errorf("creating manifest file: %s", err.Error())
 			}
@@ -340,7 +340,6 @@ func (task *taskType) checkTransfer() error {
 			if err != nil {
 				return fmt.Errorf("writing manifest file content: %s", err.Error())
 			}
-			task.ManifestFile = manifestFile.Name()
 			err = manifestFile.Close()
 			if err != nil {
 				return fmt.Errorf("closing manifest file: %s", err.Error())


### PR DESCRIPTION
This should be merged after #78.

Closes #74