### PR TITLE
Code cleanup and a fix for persistent JDP staging operations

### DIFF
--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -23,6 +23,7 @@ package jdp
 
 import (
 	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -330,6 +331,24 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 func (db *Database) LocalUser(orcid string) (string, error) {
 	// no current mechanism for this
 	return "localuser", nil
+}
+
+func (db Database) Save() (databases.DatabaseSaveState, error) {
+	var buffer bytes.Buffer
+	enc := gob.NewEncoder(&buffer)
+	err := enc.Encode(db.StagingIds)
+	if err != nil {
+		return databases.DatabaseSaveState{}, err
+	}
+	return databases.DatabaseSaveState{
+		Name: "NMDC",
+		Data: buffer.Bytes(),
+	}, nil
+}
+
+func (db *Database) Load(state databases.DatabaseSaveState) error {
+	enc := gob.NewDecoder(bytes.NewReader(state.Data))
+	return enc.Decode(&db.StagingIds)
 }
 
 //--------------------

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -216,7 +216,7 @@ func (db *Database) Resources(fileIds []string) ([]frictionless.DataResource, er
 			MD5Sum:       md.Source.MD5Sum,
 		}
 		resources[index] = dataResourceFromFile(file)
-		if resources[index].Path == "" || resources[index].Path == "/" { // permissions probem
+		if resources[index].Path == "" || resources[index].Path == "/" { // permissions problem
 			return nil, &PermissionDeniedError{fileIds[index]}
 		}
 
@@ -330,9 +330,8 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 		}
 		if status, ok := statusForString[jdpResult.Status]; ok {
 			return status, nil
-		} else {
-			return status, fmt.Errorf("Unrecognized staging status string: %s", jdpResult.Status)
 		}
+		return databases.StagingStatusUnknown, fmt.Errorf("Unrecognized staging status string: %s", jdpResult.Status)
 	} else {
 		return databases.StagingStatusUnknown, nil
 	}

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -58,6 +58,7 @@ type Database struct {
 	// SSO token used for interim JDP access
 	SsoToken string
 	// mapping from staging UUIDs to JDP restoration request ID
+	// FIXME: not persistent between service restarts!!
 	StagingIds map[uuid.UUID]int
 }
 
@@ -290,6 +291,7 @@ func (db *Database) StageFiles(fileIds []string) (uuid.UUID, error) {
 }
 
 func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error) {
+	// FIXME: db.StagingIds is not persistent between service restarts!!
 	if restoreId, found := db.StagingIds[id]; found {
 		resource := fmt.Sprintf("request_archived_files/requests/%d", restoreId)
 		resp, err := db.get(resource, url.Values{})

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -44,289 +44,6 @@ import (
 	"github.com/kbase/dts/frictionless"
 )
 
-const (
-	jdpBaseURL     = "https://files.jgi.doe.gov/"
-	filePathPrefix = "/global/dna/dm_archive/" // directory containing JDP files
-)
-
-// this error type is returned when a file is requested for which the requester
-// does not have permission
-type PermissionDeniedError struct {
-	fileId string
-}
-
-func (e PermissionDeniedError) Error() string {
-	return fmt.Sprintf("Can't access file %s: permission denied.", e.fileId)
-}
-
-// this error type is returned when a file is requested and is not found
-type FileIdNotFoundError struct {
-	fileId string
-}
-
-func (e FileIdNotFoundError) Error() string {
-	return fmt.Sprintf("Can't access file %s: not found.", e.fileId)
-}
-
-// a mapping from file suffixes to format labels
-var suffixToFormat = map[string]string{
-	"bam":      "bam",
-	"bam.bai":  "bai",
-	"blasttab": "blast",
-	"bz":       "bzip",
-	"bz2":      "bzip2",
-	"csv":      "csv",
-	"faa":      "fasta",
-	"fasta":    "fasta",
-	"fasta.gz": "fasta",
-	"fastq":    "fastq",
-	"fastq.gz": "fastq",
-	"fna":      "fasta",
-	"gff":      "gff",
-	"gff3":     "gff3",
-	"gz":       "gz",
-	"html":     "html",
-	"info":     "texinfo",
-	"out":      "text",
-	"pdf":      "pdf",
-	"tar":      "tar",
-	"tar.gz":   "tar",
-	"tar.bz":   "tar",
-	"tar.bz2":  "tar",
-	"tsv":      "tsv",
-	"txt":      "text",
-}
-
-// this gets populated automatically with the keys in suffixToFormat
-var supportedSuffixes []string
-
-// a mapping from file format labels to mime types
-var formatToMimeType = map[string]string{
-	"bam":   "application/octet-stream",
-	"bai":   "application/octet-stream",
-	"csv":   "text/csv",
-	"fasta": "text/plain",
-	"fastq": "text/plain",
-	"gff":   "text/plain",
-	"gff3":  "text/plain",
-	"gz":    "application/gzip",
-	"bz":    "application/x-bzip",
-	"bz2":   "application/x-bzip2",
-	"tar":   "application/x-tar",
-	"text":  "text/plain",
-}
-
-// a mapping from the JDP's reported file types to mime types
-// (backup method for determining mime types)
-var fileTypeToMimeType = map[string]string{
-	"text":     "text/plain",
-	"fasta":    "text/plain",
-	"fasta.gz": "application/gzip",
-	"fastq":    "text/plain",
-	"fastq.gz": "application/gzip",
-	"tab":      "text/plain",
-	"tar.gz":   "application/x-tar",
-	"tar.bz":   "application/x-tar",
-	"tar.bz2":  "application/x-tar",
-}
-
-// extracts the file format from the name and type of the file
-func formatFromFileName(fileName string) string {
-	// make a list of the supported suffixes if we haven't yet
-	if supportedSuffixes == nil {
-		supportedSuffixes = make([]string, 0)
-		for suffix := range suffixToFormat {
-			supportedSuffixes = append(supportedSuffixes, suffix)
-		}
-	}
-
-	// determine whether the file matches any of the supported suffixes,
-	// selecting the longest matching suffix
-	format := "unknown"
-	longestSuffix := 0
-	for _, suffix := range supportedSuffixes {
-		if strings.HasSuffix(fileName, suffix) && len(suffix) > longestSuffix {
-			format = suffixToFormat[suffix]
-			longestSuffix = len(suffix)
-		}
-	}
-	return format
-}
-
-// extracts the file format from the name and type of the file
-func mimeTypeFromFormatAndTypes(format string, fileTypes []string) string {
-	// try to match the file type to a mime type
-	for _, fileType := range fileTypes {
-		if mimeType, ok := fileTypeToMimeType[fileType]; ok {
-			return mimeType
-		}
-	}
-	// check the file format to see whether it matches a mime type
-	if mimeType, ok := formatToMimeType[format]; ok {
-		return mimeType
-	}
-	return ""
-}
-
-// extracts file type information from the given File
-func fileTypesFromFile(file File) []string {
-	// TODO: See https://pkg.go.dev/encoding/json?utm_source=godoc#example-RawMessage-Unmarshal
-	// TODO: for an example of how to unmarshal a variant type.
-	return []string{}
-}
-
-// extracts source information from the given metadata
-func sourcesFromMetadata(md Metadata) []frictionless.DataSource {
-	sources := make([]frictionless.DataSource, 0)
-	piInfo := md.Proposal.PI
-	if len(piInfo.LastName) > 0 {
-		var title string
-		if len(piInfo.FirstName) > 0 {
-			title = fmt.Sprintf("%s, %s", piInfo.LastName, piInfo.FirstName)
-			if len(piInfo.MiddleName) > 0 {
-				title += fmt.Sprintf(" %s", piInfo.MiddleName)
-			}
-			if len(piInfo.Institution) > 0 {
-				if len(piInfo.Country) > 0 {
-					title += fmt.Sprintf(" (%s, %s)", piInfo.Institution, piInfo.Country)
-				} else {
-					title += fmt.Sprintf(" (%s)", piInfo.Institution)
-				}
-			} else if len(piInfo.Country) > 0 {
-				title += fmt.Sprintf(" (%s)", piInfo.Country)
-			}
-		}
-		var doiURL string
-		if len(md.Proposal.AwardDOI) > 0 {
-			doiURL = fmt.Sprintf("https://doi.org/%s", md.Proposal.AwardDOI)
-		}
-		source := frictionless.DataSource{
-			Title: title,
-			Path:  doiURL,
-			Email: piInfo.EmailAddress,
-		}
-		sources = append(sources, source)
-	}
-	return sources
-}
-
-// creates a Frictionless DataResource-savvy name for a file:
-// * the name consists of lower case characters plus '.', '-', and '_'
-// * all forbidden characters encountered in the filename are removed
-// * a number suffix is added if needed to make the name unique
-func dataResourceName(filename string) string {
-	name := strings.ToLower(filename)
-
-	// remove any file suffix
-	lastDot := strings.LastIndex(name, ".")
-	if lastDot != -1 {
-		name = name[:lastDot]
-	}
-
-	// replace sequences of invalid characters with '_'
-	for {
-		isInvalid := func(c rune) bool {
-			return !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '_' && c != '-' && c != '.'
-		}
-		start := strings.IndexFunc(name, isInvalid)
-		if start >= 0 {
-			nameRunes := []rune(name)
-			end := start + 1
-			for end < len(name) && isInvalid(nameRunes[end]) {
-				end++
-			}
-			if end < len(name) {
-				name = name[:start] + string('_') + name[end+1:]
-			} else {
-				name = name[:start] + string('_')
-			}
-		} else {
-			break
-		}
-	}
-
-	return name
-}
-
-// creates a DataResource from a File
-func dataResourceFromFile(file File) frictionless.DataResource {
-	id := "JDP:" + file.Id
-	format := formatFromFileName(file.Name)
-	fileTypes := fileTypesFromFile(file)
-	sources := sourcesFromMetadata(file.Metadata)
-
-	// we use relative file paths in accordance with the Frictionless
-	// Data Resource specification
-	filePath := filepath.Join(strings.TrimPrefix(file.Path, filePathPrefix), file.Name)
-
-	pi := file.Metadata.Proposal.PI
-	return frictionless.DataResource{
-		Id:        id,
-		Name:      dataResourceName(file.Name),
-		Path:      filePath,
-		Format:    format,
-		MediaType: mimeTypeFromFormatAndTypes(format, fileTypes),
-		Bytes:     file.Size,
-		Hash:      file.MD5Sum,
-		Sources:   sources,
-		Credit: credit.CreditMetadata{
-			Identifier:   id,
-			ResourceType: "dataset",
-			Titles: []credit.Title{
-				{
-					Title: filePath,
-				},
-			},
-			Dates: []credit.EventDate{
-				{
-					Date:  file.Date,
-					Event: "Created",
-				},
-				{
-					Date:  file.AddedDate,
-					Event: "Accepted",
-				},
-				{
-					Date:  file.ModifiedDate,
-					Event: "Updated",
-				},
-			},
-			Publisher: credit.Organization{
-				OrganizationId:   "ROR:04xm1d337",
-				OrganizationName: "Joint Genome Institute",
-			},
-			RelatedIdentifiers: []credit.PermanentID{
-				{
-					Id:               file.Metadata.Proposal.DOI,
-					Description:      "Proposal DOI",
-					RelationshipType: "IsCitedBy",
-				},
-				{
-					Id:               file.Metadata.Proposal.AwardDOI,
-					Description:      "Awarded proposal DOI",
-					RelationshipType: "IsCitedBy",
-				},
-			},
-			Contributors: []credit.Contributor{
-				{
-					ContributorType: "Person",
-					// ContributorId: nothing yet
-					Name:       strings.TrimSpace(fmt.Sprintf("%s, %s %s", pi.LastName, pi.FirstName, pi.MiddleName)),
-					GivenName:  strings.TrimSpace(fmt.Sprintf("%s %s", pi.FirstName, pi.MiddleName)),
-					FamilyName: strings.TrimSpace(pi.LastName),
-					Affiliations: []credit.Organization{
-						{
-							OrganizationName: pi.Institution,
-						},
-					},
-					ContributorRoles: "PI",
-				},
-			},
-			Version: file.Date,
-		},
-	}
-}
-
 // file database appropriate for handling JDP searches and transfers
 // (implements the databases.Database interface)
 type Database struct {
@@ -375,144 +92,6 @@ func NewDatabase(orcid string) (databases.Database, error) {
 	}, nil
 }
 
-// adds an appropriate authorization header to given HTTP request
-func (db Database) addAuthHeader(request *http.Request) {
-	if len(db.Secret) > 0 { // use shared secret
-		request.Header.Add("Authorization", fmt.Sprintf("Token %s_%s", db.Orcid, db.Secret))
-	} else { // try SSO token
-		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", db.SsoToken))
-	}
-}
-
-// performs a GET request on the given resource, returning the resulting
-// response and error
-func (db *Database) get(resource string, values url.Values) (*http.Response, error) {
-	var u *url.URL
-	u, err := url.ParseRequestURI(jdpBaseURL)
-	if err != nil {
-		return nil, err
-	}
-	u.Path = resource
-	u.RawQuery = values.Encode()
-	res := fmt.Sprintf("%v", u)
-	slog.Debug(fmt.Sprintf("GET: %s", res))
-	req, err := http.NewRequest(http.MethodGet, res, http.NoBody)
-	if err != nil {
-		return nil, err
-	}
-	db.addAuthHeader(req)
-	return db.Client.Do(req)
-}
-
-// performs a POST request on the given resource, returning the resulting
-// response and error
-func (db *Database) post(resource string, body io.Reader) (*http.Response, error) {
-	u, err := url.ParseRequestURI(jdpBaseURL)
-	if err != nil {
-		return nil, err
-	}
-	u.Path = resource
-	res := fmt.Sprintf("%v", u)
-	slog.Debug(fmt.Sprintf("POST: %s", res))
-	req, err := http.NewRequest(http.MethodPost, res, body)
-	if err != nil {
-		return nil, err
-	}
-	db.addAuthHeader(req)
-	req.Header.Set("Content-Type", "application/json")
-	return db.Client.Do(req)
-}
-
-// this helper extracts files for the JDP /search GET query with given parameters
-func (db *Database) filesFromSearch(params url.Values) (databases.SearchResults, error) {
-	var results databases.SearchResults
-
-	idEncountered := make(map[string]bool) // keep track of duplicates
-
-	// extract any requested "extra" metadata fields (and scrub them from params)
-	var extraFields []string
-	if params.Has("extra") {
-		extraFields = strings.Split(params.Get("extra"), ",")
-		params.Del("extra")
-	}
-
-	resp, err := db.get("search", params)
-	if err != nil {
-		return results, err
-	}
-	defer resp.Body.Close()
-	var body []byte
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return results, err
-	}
-	type JDPResults struct {
-		Organisms []struct {
-			Id    string `json:"id"`
-			Files []File `json:"files"`
-		} `json:"organisms"`
-	}
-	results.Resources = make([]frictionless.DataResource, 0)
-	var jdpResults JDPResults
-	err = json.Unmarshal(body, &jdpResults)
-	if err != nil {
-		return results, err
-	}
-	for _, org := range jdpResults.Organisms {
-		resources := make([]frictionless.DataResource, 0)
-		for _, file := range org.Files {
-			res := dataResourceFromFile(file)
-
-			// add any requested additional metadata
-			if extraFields != nil {
-				extras := "{"
-				for i, field := range extraFields {
-					if i > 0 {
-						extras += ", "
-					}
-					switch field {
-					case "project_id":
-						extras += fmt.Sprintf(`"project_id": "%s"`, org.Id)
-					case "img_taxon_oid":
-						extras += fmt.Sprintf(`"img_taxon_oid": %d`, file.Metadata.IMG.TaxonOID)
-					}
-				}
-				extras += "}"
-				res.Extra = json.RawMessage(extras)
-			}
-
-			// add the resource to our results if it's not there already
-			if _, encountered := idEncountered[res.Id]; !encountered {
-				resources = append(resources, res)
-				idEncountered[res.Id] = true
-			}
-		}
-		results.Resources = append(results.Resources, resources...)
-	}
-	return results, nil
-}
-
-// returns the page number and page size corresponding to the given Pagination
-// parameters
-func pageNumberAndSize(offset, maxNum int) (int, int) {
-	pageNumber := 1
-	pageSize := 100
-	if offset > 0 {
-		if maxNum == -1 {
-			pageSize = offset
-			pageNumber = 2
-		} else {
-			pageSize = maxNum
-			pageNumber = offset/pageSize + 1
-		}
-	} else {
-		if maxNum > 0 {
-			pageSize = maxNum
-		}
-	}
-	return pageNumber, pageSize
-}
-
 func (db Database) SpecificSearchParameters() map[string]interface{} {
 	return map[string]interface{}{
 		// see https://files.jgi.doe.gov/apidoc/#/GET/search_list
@@ -523,103 +102,6 @@ func (db Database) SpecificSearchParameters() map[string]interface{} {
 		"s":                    []string{"name", "id", "title", "kingdom", "score.avg"}, // sort order
 		"extra":                []string{"img_taxon_oid", "project_id"},                 // list of requested extra fields
 	}
-}
-
-// checks JDP-specific search parameters and adds them to the given URL values
-func (db Database) addSpecificSearchParameters(params map[string]json.RawMessage, p *url.Values) error {
-	paramSpec := db.SpecificSearchParameters()
-	for name, jsonValue := range params {
-		switch name {
-		case "f": // field-specific search
-			var value string
-			err := json.Unmarshal(jsonValue, &value)
-			if err != nil {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  "Invalid search field given (must be string)",
-				}
-			}
-			acceptedValues := paramSpec["f"].([]string)
-			if slices.Contains(acceptedValues, value) {
-				p.Add(name, value)
-			} else {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  fmt.Sprintf("Invalid search field given: %s", value),
-				}
-			}
-		case "s": // sort order
-			var value string
-			err := json.Unmarshal(jsonValue, &value)
-			if err != nil {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  "Invalid JDP sort order given (must be string)",
-				}
-			}
-			acceptedValues := paramSpec["s"].([]string)
-			if slices.Contains(acceptedValues, value) {
-				p.Add(name, value)
-			} else {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  fmt.Sprintf("Invalid JDP sort order: %s", value),
-				}
-			}
-		case "d": // sort direction
-			var value string
-			err := json.Unmarshal(jsonValue, &value)
-			if err != nil {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  "Invalid JDP sort direction given (must be string)",
-				}
-			}
-			acceptedValues := paramSpec["d"].([]string)
-			if slices.Contains(acceptedValues, value) {
-				p.Add(name, value)
-			} else {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  fmt.Sprintf("Invalid JDP sort direction: %s", value),
-				}
-			}
-		case "include_private_data": // search for private data
-			var value int
-			err := json.Unmarshal(jsonValue, &value)
-			if err != nil || (value != 0 && value != 1) {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  "Invalid flag given for include_private_data (must be 0 or 1)",
-				}
-			}
-			p.Add(name, fmt.Sprintf("%d", value))
-		case "extra": // comma-separated additional fields requested
-			var value string
-			err := json.Unmarshal(jsonValue, &value)
-			if err != nil {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  "Invalid JDP requested extra field given (must be comma-delimited string)",
-				}
-			}
-			acceptedValues := paramSpec["extra"].([]string)
-			if slices.Contains(acceptedValues, value) {
-				p.Add(name, value)
-			} else {
-				return &databases.InvalidSearchParameter{
-					Database: "JDP",
-					Message:  fmt.Sprintf("Invalid requested extra field: %s", value),
-				}
-			}
-		default:
-			return &databases.InvalidSearchParameter{
-				Database: "JDP",
-				Message:  fmt.Sprintf("Unrecognized JDP-specific search parameter: %s", name),
-			}
-		}
-	}
-	return nil
 }
 
 func (db *Database) Search(params databases.SearchParameters) (databases.SearchResults, error) {
@@ -835,4 +317,507 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 func (db *Database) LocalUser(orcid string) (string, error) {
 	// no current mechanism for this
 	return "localuser", nil
+}
+
+//--------------------
+// Internal machinery
+//--------------------
+
+const (
+	jdpBaseURL     = "https://files.jgi.doe.gov/"
+	filePathPrefix = "/global/dna/dm_archive/" // directory containing JDP files
+)
+
+// a mapping from file suffixes to format labels
+var suffixToFormat = map[string]string{
+	"bam":      "bam",
+	"bam.bai":  "bai",
+	"blasttab": "blast",
+	"bz":       "bzip",
+	"bz2":      "bzip2",
+	"csv":      "csv",
+	"faa":      "fasta",
+	"fasta":    "fasta",
+	"fasta.gz": "fasta",
+	"fastq":    "fastq",
+	"fastq.gz": "fastq",
+	"fna":      "fasta",
+	"gff":      "gff",
+	"gff3":     "gff3",
+	"gz":       "gz",
+	"html":     "html",
+	"info":     "texinfo",
+	"out":      "text",
+	"pdf":      "pdf",
+	"tar":      "tar",
+	"tar.gz":   "tar",
+	"tar.bz":   "tar",
+	"tar.bz2":  "tar",
+	"tsv":      "tsv",
+	"txt":      "text",
+}
+
+// this gets populated automatically with the keys in suffixToFormat
+var supportedSuffixes []string
+
+// a mapping from file format labels to mime types
+var formatToMimeType = map[string]string{
+	"bam":   "application/octet-stream",
+	"bai":   "application/octet-stream",
+	"csv":   "text/csv",
+	"fasta": "text/plain",
+	"fastq": "text/plain",
+	"gff":   "text/plain",
+	"gff3":  "text/plain",
+	"gz":    "application/gzip",
+	"bz":    "application/x-bzip",
+	"bz2":   "application/x-bzip2",
+	"tar":   "application/x-tar",
+	"text":  "text/plain",
+}
+
+// a mapping from the JDP's reported file types to mime types
+// (backup method for determining mime types)
+var fileTypeToMimeType = map[string]string{
+	"text":     "text/plain",
+	"fasta":    "text/plain",
+	"fasta.gz": "application/gzip",
+	"fastq":    "text/plain",
+	"fastq.gz": "application/gzip",
+	"tab":      "text/plain",
+	"tar.gz":   "application/x-tar",
+	"tar.bz":   "application/x-tar",
+	"tar.bz2":  "application/x-tar",
+}
+
+// extracts the file format from the name and type of the file
+func formatFromFileName(fileName string) string {
+	// make a list of the supported suffixes if we haven't yet
+	if supportedSuffixes == nil {
+		supportedSuffixes = make([]string, 0)
+		for suffix := range suffixToFormat {
+			supportedSuffixes = append(supportedSuffixes, suffix)
+		}
+	}
+
+	// determine whether the file matches any of the supported suffixes,
+	// selecting the longest matching suffix
+	format := "unknown"
+	longestSuffix := 0
+	for _, suffix := range supportedSuffixes {
+		if strings.HasSuffix(fileName, suffix) && len(suffix) > longestSuffix {
+			format = suffixToFormat[suffix]
+			longestSuffix = len(suffix)
+		}
+	}
+	return format
+}
+
+// extracts the file format from the name and type of the file
+func mimeTypeFromFormatAndTypes(format string, fileTypes []string) string {
+	// try to match the file type to a mime type
+	for _, fileType := range fileTypes {
+		if mimeType, ok := fileTypeToMimeType[fileType]; ok {
+			return mimeType
+		}
+	}
+	// check the file format to see whether it matches a mime type
+	if mimeType, ok := formatToMimeType[format]; ok {
+		return mimeType
+	}
+	return ""
+}
+
+// extracts file type information from the given File
+func fileTypesFromFile(_ File) []string {
+	// TODO: See https://pkg.go.dev/encoding/json?utm_source=godoc#example-RawMessage-Unmarshal
+	// TODO: for an example of how to unmarshal a variant type.
+	return []string{}
+}
+
+// extracts source information from the given metadata
+func sourcesFromMetadata(md Metadata) []frictionless.DataSource {
+	sources := make([]frictionless.DataSource, 0)
+	piInfo := md.Proposal.PI
+	if len(piInfo.LastName) > 0 {
+		var title string
+		if len(piInfo.FirstName) > 0 {
+			title = fmt.Sprintf("%s, %s", piInfo.LastName, piInfo.FirstName)
+			if len(piInfo.MiddleName) > 0 {
+				title += fmt.Sprintf(" %s", piInfo.MiddleName)
+			}
+			if len(piInfo.Institution) > 0 {
+				if len(piInfo.Country) > 0 {
+					title += fmt.Sprintf(" (%s, %s)", piInfo.Institution, piInfo.Country)
+				} else {
+					title += fmt.Sprintf(" (%s)", piInfo.Institution)
+				}
+			} else if len(piInfo.Country) > 0 {
+				title += fmt.Sprintf(" (%s)", piInfo.Country)
+			}
+		}
+		var doiURL string
+		if len(md.Proposal.AwardDOI) > 0 {
+			doiURL = fmt.Sprintf("https://doi.org/%s", md.Proposal.AwardDOI)
+		}
+		source := frictionless.DataSource{
+			Title: title,
+			Path:  doiURL,
+			Email: piInfo.EmailAddress,
+		}
+		sources = append(sources, source)
+	}
+	return sources
+}
+
+// creates a Frictionless DataResource-savvy name for a file:
+// * the name consists of lower case characters plus '.', '-', and '_'
+// * all forbidden characters encountered in the filename are removed
+// * a number suffix is added if needed to make the name unique
+func dataResourceName(filename string) string {
+	name := strings.ToLower(filename)
+
+	// remove any file suffix
+	lastDot := strings.LastIndex(name, ".")
+	if lastDot != -1 {
+		name = name[:lastDot]
+	}
+
+	// replace sequences of invalid characters with '_'
+	for {
+		isInvalid := func(c rune) bool {
+			return !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '_' && c != '-' && c != '.'
+		}
+		start := strings.IndexFunc(name, isInvalid)
+		if start >= 0 {
+			nameRunes := []rune(name)
+			end := start + 1
+			for end < len(name) && isInvalid(nameRunes[end]) {
+				end++
+			}
+			if end < len(name) {
+				name = name[:start] + string('_') + name[end+1:]
+			} else {
+				name = name[:start] + string('_')
+			}
+		} else {
+			break
+		}
+	}
+
+	return name
+}
+
+// creates a DataResource from a File
+func dataResourceFromFile(file File) frictionless.DataResource {
+	id := "JDP:" + file.Id
+	format := formatFromFileName(file.Name)
+	fileTypes := fileTypesFromFile(file)
+	sources := sourcesFromMetadata(file.Metadata)
+
+	// we use relative file paths in accordance with the Frictionless
+	// Data Resource specification
+	filePath := filepath.Join(strings.TrimPrefix(file.Path, filePathPrefix), file.Name)
+
+	pi := file.Metadata.Proposal.PI
+	return frictionless.DataResource{
+		Id:        id,
+		Name:      dataResourceName(file.Name),
+		Path:      filePath,
+		Format:    format,
+		MediaType: mimeTypeFromFormatAndTypes(format, fileTypes),
+		Bytes:     file.Size,
+		Hash:      file.MD5Sum,
+		Sources:   sources,
+		Credit: credit.CreditMetadata{
+			Identifier:   id,
+			ResourceType: "dataset",
+			Titles: []credit.Title{
+				{
+					Title: filePath,
+				},
+			},
+			Dates: []credit.EventDate{
+				{
+					Date:  file.Date,
+					Event: "Created",
+				},
+				{
+					Date:  file.AddedDate,
+					Event: "Accepted",
+				},
+				{
+					Date:  file.ModifiedDate,
+					Event: "Updated",
+				},
+			},
+			Publisher: credit.Organization{
+				OrganizationId:   "ROR:04xm1d337",
+				OrganizationName: "Joint Genome Institute",
+			},
+			RelatedIdentifiers: []credit.PermanentID{
+				{
+					Id:               file.Metadata.Proposal.DOI,
+					Description:      "Proposal DOI",
+					RelationshipType: "IsCitedBy",
+				},
+				{
+					Id:               file.Metadata.Proposal.AwardDOI,
+					Description:      "Awarded proposal DOI",
+					RelationshipType: "IsCitedBy",
+				},
+			},
+			Contributors: []credit.Contributor{
+				{
+					ContributorType: "Person",
+					// ContributorId: nothing yet
+					Name:       strings.TrimSpace(fmt.Sprintf("%s, %s %s", pi.LastName, pi.FirstName, pi.MiddleName)),
+					GivenName:  strings.TrimSpace(fmt.Sprintf("%s %s", pi.FirstName, pi.MiddleName)),
+					FamilyName: strings.TrimSpace(pi.LastName),
+					Affiliations: []credit.Organization{
+						{
+							OrganizationName: pi.Institution,
+						},
+					},
+					ContributorRoles: "PI",
+				},
+			},
+			Version: file.Date,
+		},
+	}
+}
+
+// adds an appropriate authorization header to given HTTP request
+func (db Database) addAuthHeader(request *http.Request) {
+	if len(db.Secret) > 0 { // use shared secret
+		request.Header.Add("Authorization", fmt.Sprintf("Token %s_%s", db.Orcid, db.Secret))
+	} else { // try SSO token
+		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", db.SsoToken))
+	}
+}
+
+// performs a GET request on the given resource, returning the resulting
+// response and error
+func (db *Database) get(resource string, values url.Values) (*http.Response, error) {
+	var u *url.URL
+	u, err := url.ParseRequestURI(jdpBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = resource
+	u.RawQuery = values.Encode()
+	res := fmt.Sprintf("%v", u)
+	slog.Debug(fmt.Sprintf("GET: %s", res))
+	req, err := http.NewRequest(http.MethodGet, res, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	db.addAuthHeader(req)
+	return db.Client.Do(req)
+}
+
+// performs a POST request on the given resource, returning the resulting
+// response and error
+func (db *Database) post(resource string, body io.Reader) (*http.Response, error) {
+	u, err := url.ParseRequestURI(jdpBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = resource
+	res := fmt.Sprintf("%v", u)
+	slog.Debug(fmt.Sprintf("POST: %s", res))
+	req, err := http.NewRequest(http.MethodPost, res, body)
+	if err != nil {
+		return nil, err
+	}
+	db.addAuthHeader(req)
+	req.Header.Set("Content-Type", "application/json")
+	return db.Client.Do(req)
+}
+
+// this helper extracts files for the JDP /search GET query with given parameters
+func (db *Database) filesFromSearch(params url.Values) (databases.SearchResults, error) {
+	var results databases.SearchResults
+
+	idEncountered := make(map[string]bool) // keep track of duplicates
+
+	// extract any requested "extra" metadata fields (and scrub them from params)
+	var extraFields []string
+	if params.Has("extra") {
+		extraFields = strings.Split(params.Get("extra"), ",")
+		params.Del("extra")
+	}
+
+	resp, err := db.get("search", params)
+	if err != nil {
+		return results, err
+	}
+	defer resp.Body.Close()
+	var body []byte
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return results, err
+	}
+	type JDPResults struct {
+		Organisms []struct {
+			Id    string `json:"id"`
+			Files []File `json:"files"`
+		} `json:"organisms"`
+	}
+	results.Resources = make([]frictionless.DataResource, 0)
+	var jdpResults JDPResults
+	err = json.Unmarshal(body, &jdpResults)
+	if err != nil {
+		return results, err
+	}
+	for _, org := range jdpResults.Organisms {
+		resources := make([]frictionless.DataResource, 0)
+		for _, file := range org.Files {
+			res := dataResourceFromFile(file)
+
+			// add any requested additional metadata
+			if extraFields != nil {
+				extras := "{"
+				for i, field := range extraFields {
+					if i > 0 {
+						extras += ", "
+					}
+					switch field {
+					case "project_id":
+						extras += fmt.Sprintf(`"project_id": "%s"`, org.Id)
+					case "img_taxon_oid":
+						extras += fmt.Sprintf(`"img_taxon_oid": %d`, file.Metadata.IMG.TaxonOID)
+					}
+				}
+				extras += "}"
+				res.Extra = json.RawMessage(extras)
+			}
+
+			// add the resource to our results if it's not there already
+			if _, encountered := idEncountered[res.Id]; !encountered {
+				resources = append(resources, res)
+				idEncountered[res.Id] = true
+			}
+		}
+		results.Resources = append(results.Resources, resources...)
+	}
+	return results, nil
+}
+
+// returns the page number and page size corresponding to the given Pagination
+// parameters
+func pageNumberAndSize(offset, maxNum int) (int, int) {
+	pageNumber := 1
+	pageSize := 100
+	if offset > 0 {
+		if maxNum == -1 {
+			pageSize = offset
+			pageNumber = 2
+		} else {
+			pageSize = maxNum
+			pageNumber = offset/pageSize + 1
+		}
+	} else {
+		if maxNum > 0 {
+			pageSize = maxNum
+		}
+	}
+	return pageNumber, pageSize
+}
+
+// checks JDP-specific search parameters and adds them to the given URL values
+func (db Database) addSpecificSearchParameters(params map[string]json.RawMessage, p *url.Values) error {
+	paramSpec := db.SpecificSearchParameters()
+	for name, jsonValue := range params {
+		switch name {
+		case "f": // field-specific search
+			var value string
+			err := json.Unmarshal(jsonValue, &value)
+			if err != nil {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  "Invalid search field given (must be string)",
+				}
+			}
+			acceptedValues := paramSpec["f"].([]string)
+			if slices.Contains(acceptedValues, value) {
+				p.Add(name, value)
+			} else {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  fmt.Sprintf("Invalid search field given: %s", value),
+				}
+			}
+		case "s": // sort order
+			var value string
+			err := json.Unmarshal(jsonValue, &value)
+			if err != nil {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  "Invalid JDP sort order given (must be string)",
+				}
+			}
+			acceptedValues := paramSpec["s"].([]string)
+			if slices.Contains(acceptedValues, value) {
+				p.Add(name, value)
+			} else {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  fmt.Sprintf("Invalid JDP sort order: %s", value),
+				}
+			}
+		case "d": // sort direction
+			var value string
+			err := json.Unmarshal(jsonValue, &value)
+			if err != nil {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  "Invalid JDP sort direction given (must be string)",
+				}
+			}
+			acceptedValues := paramSpec["d"].([]string)
+			if slices.Contains(acceptedValues, value) {
+				p.Add(name, value)
+			} else {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  fmt.Sprintf("Invalid JDP sort direction: %s", value),
+				}
+			}
+		case "include_private_data": // search for private data
+			var value int
+			err := json.Unmarshal(jsonValue, &value)
+			if err != nil || (value != 0 && value != 1) {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  "Invalid flag given for include_private_data (must be 0 or 1)",
+				}
+			}
+			p.Add(name, fmt.Sprintf("%d", value))
+		case "extra": // comma-separated additional fields requested
+			var value string
+			err := json.Unmarshal(jsonValue, &value)
+			if err != nil {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  "Invalid JDP requested extra field given (must be comma-delimited string)",
+				}
+			}
+			acceptedValues := paramSpec["extra"].([]string)
+			if slices.Contains(acceptedValues, value) {
+				p.Add(name, value)
+			} else {
+				return &databases.InvalidSearchParameter{
+					Database: "JDP",
+					Message:  fmt.Sprintf("Invalid requested extra field: %s", value),
+				}
+			}
+		default:
+			return &databases.InvalidSearchParameter{
+				Database: "JDP",
+				Message:  fmt.Sprintf("Unrecognized JDP-specific search parameter: %s", name),
+			}
+		}
+	}
+	return nil
 }

--- a/databases/jdp/errors.go
+++ b/databases/jdp/errors.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package jdp
+
+import (
+	"fmt"
+)
+
+// this error type is returned when a file is requested for which the requester
+// does not have permission
+type PermissionDeniedError struct {
+	fileId string
+}
+
+func (e PermissionDeniedError) Error() string {
+	return fmt.Sprintf("Can't access file %s: permission denied.", e.fileId)
+}
+
+// this error type is returned when a file is requested and is not found
+type FileIdNotFoundError struct {
+	fileId string
+}
+
+func (e FileIdNotFoundError) Error() string {
+	return fmt.Sprintf("Can't access file %s: not found.", e.fileId)
+}

--- a/databases/kbase/database.go
+++ b/databases/kbase/database.go
@@ -77,3 +77,15 @@ func (db *Database) LocalUser(orcid string) (string, error) {
 	// auth server proxy
 	return auth.KBaseLocalUsernameForOrcid(orcid)
 }
+
+func (db Database) Save() (databases.DatabaseSaveState, error) {
+	// so far, this database has no internal state
+	return databases.DatabaseSaveState{
+		Name: "kbase",
+	}, nil
+}
+
+func (db *Database) Load(state databases.DatabaseSaveState) error {
+	// no internal state -> nothing to do
+	return nil
+}

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -237,6 +237,18 @@ func (db Database) LocalUser(orcid string) (string, error) {
 	return "localuser", nil
 }
 
+func (db Database) Save() (databases.DatabaseSaveState, error) {
+	// so far, this database has no internal state
+	return databases.DatabaseSaveState{
+		Name: "NMDC",
+	}, nil
+}
+
+func (db *Database) Load(state databases.DatabaseSaveState) error {
+	// no internal state -> nothing to do
+	return nil
+}
+
 //--------------------
 // Internal machinery
 //--------------------

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -240,7 +240,7 @@ func (db Database) LocalUser(orcid string) (string, error) {
 func (db Database) Save() (databases.DatabaseSaveState, error) {
 	// so far, this database has no internal state
 	return databases.DatabaseSaveState{
-		Name: "NMDC",
+		Name: "nmdc",
 	}, nil
 }
 

--- a/dtstest/dtstest.go
+++ b/dtstest/dtstest.go
@@ -276,3 +276,11 @@ func (db *Database) Endpoint() (endpoints.Endpoint, error) {
 func (db *Database) LocalUser(orcid string) (string, error) {
 	return "testuser", nil
 }
+
+func (db *Database) Save() (databases.DatabaseSaveState, error) {
+	return databases.DatabaseSaveState{}, nil
+}
+
+func (db *Database) Load(state databases.DatabaseSaveState) error {
+	return nil
+}

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -309,17 +309,15 @@ func (ep *Endpoint) Status(id uuid.UUID) (endpoints.TransferStatus, error) {
 			}
 		} else {
 			// it's probably real
-			if err == nil {
-				// find the first error event
-				for _, event := range eventList.Data {
-					if event.IsError {
-						// sometimes Globus throws an AUTH error here during a network burp, so we
-						// ignore it and report a failed status check (after all, we can't get here
-						// without AUTHing successfully!)
-						return endpoints.TransferStatus{},
-							fmt.Errorf("%s (%s):\n%s", event.Description, event.Code,
-								event.Details)
-					}
+			// find the first error event
+			for _, event := range eventList.Data {
+				if event.IsError {
+					// sometimes Globus throws an AUTH error here during a network burp, so we
+					// ignore it and report a failed status check (after all, we can't get here
+					// without AUTHing successfully!)
+					return endpoints.TransferStatus{},
+						fmt.Errorf("%s (%s):\n%s", event.Description, event.Code,
+							event.Details)
 				}
 			}
 			// fall back to the "nice status"

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -60,14 +60,6 @@ func (e GlobusError) Error() string {
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
 }
 
-// returns true if a Globus response body matches an error
-func responseIsError(body []byte) bool {
-	bodyStr := string(body)
-	return strings.Contains(bodyStr, "\"code\"") &&
-		!strings.Contains(bodyStr, "\"code\": \"Accepted\"") &&
-		strings.Contains(string(body), "\"message\"")
-}
-
 // this type satisfies the endpoints.Endpoint interface for Globus endpoints
 type Endpoint struct {
 	// descriptive endpoint name (obtained from config)
@@ -150,7 +142,7 @@ func (ep *Endpoint) FilesStaged(files []frictionless.DataResource) (bool, error)
 	// (https://docs.globus.org/api/transfer/file_operations/#list_directory_contents)
 	for dir, files := range filesInDir {
 		values := url.Values{}
-		values.Add("path", "/"+dir)
+		values.Add("path", dir)
 		values.Add("orderby", "name ASC")
 		resource := fmt.Sprintf("operation/endpoint/%s/ls", ep.Id.String())
 		body, err := ep.get(resource, values)
@@ -159,10 +151,6 @@ func (ep *Endpoint) FilesStaged(files []frictionless.DataResource) (bool, error)
 			switch globusErr.Code {
 			case "ClientError.NotFound":
 				// it's okay if the directory doesn't exist -- it might need to be staged
-				return false, nil
-			case "ExternalError.DirListingFailed.LoginFailed":
-				// unfortunately, Globus throws this error when there's a network hiccup,
-				// so we can't take it seriously as an actual error condition
 				return false, nil
 			default:
 				// propagate the error
@@ -366,6 +354,18 @@ func (ep *Endpoint) Cancel(id uuid.UUID) error {
 		}
 	}
 	return err
+}
+
+//-----------
+// Internals
+//-----------
+
+// returns true if a Globus response body matches an error
+func responseIsError(body []byte) bool {
+	bodyStr := string(body)
+	return strings.Contains(bodyStr, "\"code\"") &&
+		!strings.Contains(bodyStr, "\"code\": \"Accepted\"") &&
+		strings.Contains(string(body), "\"message\"")
 }
 
 // (re)authenticates with Globus using its client ID and secret to obtain an

--- a/tasks/errors.go
+++ b/tasks/errors.go
@@ -52,6 +52,13 @@ func (t NotRunningError) Error() string {
 	return fmt.Sprintf("Tasks are not currently being processed.")
 }
 
+// indicates that a transfer has been requested with no files(!)
+type NoFilesRequestedError struct{}
+
+func (t NoFilesRequestedError) Error() string {
+	return fmt.Sprintf("Requested transfer task with no files!")
+}
+
 // indicates that a payload has been requested that is too large
 type PayloadTooLargeError struct {
 	size float64 // size of the requested payload in gigabytes

--- a/tasks/errors.go
+++ b/tasks/errors.go
@@ -56,7 +56,7 @@ func (t NotRunningError) Error() string {
 type NoFilesRequestedError struct{}
 
 func (t NoFilesRequestedError) Error() string {
-	return fmt.Sprintf("Requested transfer task with no files!")
+	return fmt.Sprintf("Requested transfer task includes no file IDs!")
 }
 
 // indicates that a payload has been requested that is too large

--- a/tasks/errors.go
+++ b/tasks/errors.go
@@ -61,10 +61,10 @@ func (t NoFilesRequestedError) Error() string {
 
 // indicates that a payload has been requested that is too large
 type PayloadTooLargeError struct {
-	size float64 // size of the requested payload in gigabytes
+	Size float64 // size of the requested payload in gigabytes
 }
 
 func (e PayloadTooLargeError) Error() string {
 	return fmt.Sprintf("Requested payload is too large: %g GB (limit is %g GB).",
-		e.size, config.Service.MaxPayloadSize)
+		e.Size, config.Service.MaxPayloadSize)
 }

--- a/tasks/subtask.go
+++ b/tasks/subtask.go
@@ -37,7 +37,7 @@ import (
 // multiple endpoints attached to a single source/destination database pair).
 // It holds multiple (possibly null) UUIDs corresponding to different
 // states in the file transfer lifecycle
-type TransferSubtask struct {
+type transferSubtask struct {
 	Destination         string                  // name of destination database (in config)
 	DestinationEndpoint string                  // name of destination database (in config)
 	DestinationFolder   string                  // folder path to which files are transferred
@@ -51,7 +51,7 @@ type TransferSubtask struct {
 	UserInfo            auth.UserInfo           // info about user requesting transfer
 }
 
-func (subtask *TransferSubtask) start() error {
+func (subtask *transferSubtask) start() error {
 	// are the files already staged? (only works for public data)
 	sourceEndpoint, err := endpoints.NewEndpoint(subtask.SourceEndpoint)
 	if err != nil {
@@ -89,7 +89,7 @@ func (subtask *TransferSubtask) start() error {
 }
 
 // updates the state of a subtask, setting its status as necessary
-func (subtask *TransferSubtask) update() error {
+func (subtask *transferSubtask) update() error {
 	var err error
 	if subtask.Staging.Valid { // we're staging
 		err = subtask.checkStaging()
@@ -100,7 +100,7 @@ func (subtask *TransferSubtask) update() error {
 }
 
 // initiates a file transfer on a set of staged files
-func (subtask *TransferSubtask) beginTransfer() error {
+func (subtask *transferSubtask) beginTransfer() error {
 	slog.Debug(fmt.Sprintf("Transferring %d file(s) from %s to %s",
 		len(subtask.Resources), subtask.SourceEndpoint, subtask.DestinationEndpoint))
 	// assemble a list of file transfers
@@ -139,7 +139,7 @@ func (subtask *TransferSubtask) beginTransfer() error {
 
 // checks whether files for a subtask are finished staging and, if so,
 // initiates the transfer process
-func (subtask *TransferSubtask) checkStaging() error {
+func (subtask *transferSubtask) checkStaging() error {
 	source, err := databases.NewDatabase(subtask.UserInfo.Orcid, subtask.Source)
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func (subtask *TransferSubtask) checkStaging() error {
 
 // checks whether files for a task are finished transferring and, if so,
 // initiates the generation of the file manifest
-func (subtask *TransferSubtask) checkTransfer() error {
+func (subtask *transferSubtask) checkTransfer() error {
 	// has the data transfer completed?
 	sourceEndpoint, err := endpoints.NewEndpoint(subtask.SourceEndpoint)
 	if err != nil {
@@ -183,7 +183,7 @@ func (subtask *TransferSubtask) checkTransfer() error {
 }
 
 // issues a cancellation request to the endpoint associated with the subtask
-func (subtask *TransferSubtask) cancel() error {
+func (subtask *transferSubtask) cancel() error {
 	if subtask.Transfer.Valid { // we're transferring
 		// fetch the source endpoint
 		endpoint, err := endpoints.NewEndpoint(subtask.SourceEndpoint)
@@ -199,7 +199,7 @@ func (subtask *TransferSubtask) cancel() error {
 
 // updates the status of a canceled subtask depending on where it is in its
 // lifecycle
-func (subtask *TransferSubtask) checkCancellation() error {
+func (subtask *transferSubtask) checkCancellation() error {
 	if subtask.Transfer.Valid {
 		endpoint, err := endpoints.NewEndpoint(subtask.SourceEndpoint)
 		if err != nil {

--- a/tasks/subtask.go
+++ b/tasks/subtask.go
@@ -117,8 +117,14 @@ func (subtask *transferSubtask) checkStaging() error {
 
 	if subtask.StagingStatus == databases.StagingStatusSucceeded { // staged!
 		// the database thinks the files are staged. Does its endpoint agree?
-		endpoint, _ := endpoints.NewEndpoint(subtask.SourceEndpoint)
-		staged, _ := endpoint.FilesStaged(subtask.Resources)
+		endpoint, err := endpoints.NewEndpoint(subtask.SourceEndpoint)
+		if err != nil {
+			return err
+		}
+		staged, err := endpoint.FilesStaged(subtask.Resources)
+		if err != nil {
+			return err
+		}
 		if !staged {
 			return fmt.Errorf("Database %s reports staged files, but endpoint %s cannot see them. Is the endpoint's root set properly?",
 				subtask.Source, subtask.SourceEndpoint)

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -57,7 +57,7 @@ type transferTask struct {
 	UserInfo          auth.UserInfo     // info about user requesting transfer
 }
 
-// computes the size of a payload for a transfer task (in gigabytes)
+// computes the size of a payload for a transfer task (in Gigabytes)
 func payloadSize(resources []DataResource) float64 {
 	var size uint64
 	for _, resource := range resources {
@@ -106,7 +106,7 @@ func (task *transferTask) start() error {
 	// make sure the size of the payload doesn't exceed our specified limit
 	task.PayloadSize = payloadSize(resources) // (in GB)
 	if task.PayloadSize > config.Service.MaxPayloadSize {
-		return &PayloadTooLargeError{size: task.PayloadSize}
+		return &PayloadTooLargeError{Size: task.PayloadSize}
 	}
 
 	// determine the destination endpoint

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -223,17 +223,17 @@ func (task *transferTask) Update() error {
 			task.Status.NumFilesTransferred = 0
 			task.Status.NumFilesSkipped = 0
 			for _, subtask := range task.Subtasks {
+				task.Status.NumFiles += subtask.TransferStatus.NumFiles
 				if subtask.Staging.Valid {
 					subtaskStaging = true
 				} else if subtask.Transfer.Valid {
-					task.Status.NumFiles += subtask.TransferStatus.NumFiles
 					task.Status.NumFilesTransferred += subtask.TransferStatus.NumFilesTransferred
 					task.Status.NumFilesSkipped += subtask.TransferStatus.NumFilesSkipped
 				}
 			}
 		}
 
-		if subtaskStaging && task.Status.NumFiles == 0 {
+		if subtaskStaging && task.Status.NumFilesTransferred == 0 {
 			task.Status.Code = TransferStatusStaging
 		} else if allTransfersSucceeded { // write a manifest
 			localEndpoint, err := endpoints.NewEndpoint(config.Service.Endpoint)

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -37,9 +37,9 @@ import (
 )
 
 // This type tracks the lifecycle of a file transfer task that copies files from
-// a source database to a destination database. A TransferTask can have one or
+// a source database to a destination database. A transferTask can have one or
 // more subtasks, depending on how many transfer endpoints are involved.
-type TransferTask struct {
+type transferTask struct {
 	Canceled          bool              // set if a cancellation request has been made
 	CompletionTime    time.Time         // time at which the transfer completed
 	Description       string            // Markdown description of the task
@@ -53,7 +53,7 @@ type TransferTask struct {
 	PayloadSize       float64           // Size of payload (gigabytes)
 	Source            string            // name of source database (in config)
 	Status            TransferStatus    // status of file transfer operation
-	Subtasks          []TransferSubtask // list of constituent file transfer subtasks
+	Subtasks          []transferSubtask // list of constituent file transfer subtasks
 	UserInfo          auth.UserInfo     // info about user requesting transfer
 }
 
@@ -67,7 +67,7 @@ func payloadSize(resources []DataResource) float64 {
 }
 
 // starts a task going, initiating staging if needed
-func (task *TransferTask) start() error {
+func (task *transferTask) start() error {
 	source, err := databases.NewDatabase(task.UserInfo.Orcid, task.Source)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func (task *TransferTask) start() error {
 			distinctEndpoints[resource.Endpoint] = struct{}{}
 		}
 	}
-	task.Subtasks = make([]TransferSubtask, 0)
+	task.Subtasks = make([]transferSubtask, 0)
 	for sourceEndpoint := range distinctEndpoints {
 		// pick out the files corresponding to the source endpoint
 		// NOTE: this is slow, but preserves file ID ordering
@@ -143,7 +143,7 @@ func (task *TransferTask) start() error {
 		}
 
 		// set up a subtask for the endpoint
-		task.Subtasks = append(task.Subtasks, TransferSubtask{
+		task.Subtasks = append(task.Subtasks, transferSubtask{
 			Destination:         task.Destination,
 			DestinationEndpoint: destinationEndpoint,
 			DestinationFolder:   task.DestinationFolder,
@@ -168,7 +168,7 @@ func (task *TransferTask) start() error {
 }
 
 // updates the state of a task, setting its status as necessary
-func (task *TransferTask) Update() error {
+func (task *transferTask) Update() error {
 	var err error
 	if len(task.Subtasks) == 0 { // new task!
 		err = task.start()
@@ -293,7 +293,7 @@ func (task *TransferTask) Update() error {
 }
 
 // requests that the task be canceled
-func (task *TransferTask) Cancel() error {
+func (task *transferTask) Cancel() error {
 	task.Canceled = true           // mark as canceled
 	for i := range task.Subtasks { // cancel subtasks
 		task.Subtasks[i].cancel()
@@ -303,7 +303,7 @@ func (task *TransferTask) Cancel() error {
 
 // returns the duration since the task completed (successfully or otherwise),
 // or 0 if the task has not completed
-func (task TransferTask) Age() time.Duration {
+func (task transferTask) Age() time.Duration {
 	if task.Status.Code == TransferStatusSucceeded ||
 		task.Status.Code == TransferStatusFailed {
 		return time.Since(task.CompletionTime)
@@ -313,7 +313,7 @@ func (task TransferTask) Age() time.Duration {
 }
 
 // returns true if the task has completed (successfully or not), false otherwise
-func (task TransferTask) Completed() bool {
+func (task transferTask) Completed() bool {
 	if task.Status.Code == TransferStatusSucceeded ||
 		task.Status.Code == TransferStatusFailed {
 		return true
@@ -323,7 +323,7 @@ func (task TransferTask) Completed() bool {
 }
 
 // creates a DataPackage that serves as the transfer manifest
-func (task *TransferTask) createManifest() DataPackage {
+func (task *transferTask) createManifest() DataPackage {
 	numResources := 0
 	for _, subtask := range task.Subtasks {
 		numResources += len(subtask.Resources)
@@ -360,7 +360,7 @@ func (task *TransferTask) createManifest() DataPackage {
 
 // checks whether the file manifest for a task has been generated and, if so,
 // marks the task as completed
-func (task *TransferTask) checkManifest() error {
+func (task *transferTask) checkManifest() error {
 	// has the manifest transfer completed?
 	localEndpoint, err := endpoints.NewEndpoint(config.Service.Endpoint)
 	if err != nil {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -258,6 +258,13 @@ func createOrLoadTasks(dataFile string) map[uuid.UUID]transferTask {
 	enc := gob.NewDecoder(file)
 	var tasks map[uuid.UUID]transferTask
 	err = enc.Decode(&tasks)
+	if err == nil {
+		var databaseStates map[string]DatabaseSaveState
+		err = enc.Decode(&databaseStates)
+		if err == nil {
+			err = databases.Load(databaseStates)
+		}
+	}
 	if err != nil { // file not readable
 		slog.Error(fmt.Sprintf("Reading task file %s: %s", dataFile, err.Error()))
 		return make(map[uuid.UUID]transferTask)
@@ -276,6 +283,10 @@ func saveTasks(tasks map[uuid.UUID]transferTask, dataFile string) error {
 		}
 		enc := gob.NewEncoder(file)
 		err = enc.Encode(tasks)
+		if err == nil {
+			databaseStates := databases.Save()
+			err = enc.Encode(databaseStates)
+		}
 		if err != nil {
 			file.Close()
 			os.Remove(dataFile)

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -179,6 +179,11 @@ type Specification struct {
 func Create(spec Specification) (uuid.UUID, error) {
 	var taskId uuid.UUID
 
+	// have we requested files to be transferred?
+	if len(spec.FileIds) == 0 {
+		return taskId, NoFilesRequestedError{}
+	}
+
 	// verify that we can fetch the task's source and destination databases
 	// without incident
 	_, err := databases.NewDatabase(spec.UserInfo.Orcid, spec.Source)

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -364,6 +364,7 @@ func processTasks() {
 		case <-pollChan: // time to move things along
 			for taskId, task := range tasks {
 				if !task.Completed() {
+					slog.Debug(fmt.Sprintf("Task %s is incomplete, proceeding...", taskId.String()))
 					oldStatus := task.Status
 					err := task.Update()
 					if err != nil {
@@ -392,6 +393,8 @@ func processTasks() {
 							slog.Info(fmt.Sprintf("Task %s: failed", task.Id.String()))
 						}
 					}
+				} else {
+					slog.Debug(fmt.Sprintf("Task %s is complete.", taskId.String()))
 				}
 
 				// if the task completed a long enough time go, delete its entry


### PR DESCRIPTION
This PR does some minor reorganization, hopefully making code easier to follow. It also introduces a mechanism for Database implementations (e.g. JDP, KBase, NMDC) to save any information required to make their state persistent between service restarts. For example, this mechanism allows our JDP proxy to maintain a table mapping a UUID for a DTS staging operation to a JDP integer token used to retrieve the actual staging status.

I've also improved error checking and propagation in a few places, which helped me identify the cause of the issue (#87) indicating the need for the persistence mechanism above.
 
Closes #87 