### PR TITLE
Possible fix for Globus "token not active" error

### DIFF
--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -442,8 +442,9 @@ func (ep *Endpoint) sendRequest(request *http.Request) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if errResp.Code == "ConsentRequired" {
-			// we're missing a required scope, so reauthenticate with it
+		if errResp.Code == "ConsentRequired" || errResp.Code == "AuthenticationFailed" {
+			// our token has expired or we're missing a required scope,
+			// so reauthenticate
 			ep.Scopes = errResp.RequiredScopes
 			err = ep.authenticate()
 			if err != nil {


### PR DESCRIPTION
This change allows the DTS to reauthenticate to Globus when an access token expires. It may fix #88. Ken Chu has reported this issue, so he's in a good position to see whether it continues with this fix, which is now deployed and running in Spin.

Closes #88 