### PR TITLE
A short-term hack to allow filtering on data objects by type.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,9 @@ type serviceConfig struct {
 	DeleteAfter int `json:"delete_after" yaml:"delete_after"`
 	// flag indicating whether debug logging and other tools are enabled
 	Debug bool `json:"debug" yaml:"debug"`
+	// flag indicating whether an endpoint double-checks that files are staged
+	// (if not set, the endpoint will trust a database for staging status)
+	DoubleCheckStaging bool `json:"double_check_staging" yaml:"double_check_staging"`
 }
 
 // global config variables

--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -27,12 +27,14 @@ Each of these sections is described below, with a motivating example.
 service:
   port: 8080
   max_connections: 100
+  max_payload_size: 50
   poll_interval:   60000
   endpoint: globus-local
   data_dir: /path/to/dir
   manifest_dir: /path/to/dir
   delete_after: 604800
   debug: true
+  double_check_staging: false
 ```
 
 The `service` section contains parameters that control nuts-and-bolts behavior
@@ -43,6 +45,9 @@ section are:
 * `max_connections`: the maximum number of connections that are simultaneously
   available for DTS clients. If a client sends a request to the DTS when all
   connections are occupied, the request is denied.
+* `max_payload_size`: the maximum payload size (in GB) allowed by the service.
+  If a client requests the transfer of a payload larger than this size, the
+  request is denied.
 * `poll_interval`: the interval (in milliseconds) at which the DTS checks for
   progress in any ongoing transfers. Because the file transfers orchestrated by
   the DTS typically take a long time, it's reasonable to set this parameter to
@@ -67,6 +72,9 @@ section are:
 * `debug`: an optional parameter that, if set to `true`, enables more detailed
   logging and other features that are helpful for troubleshooting and
   development work. The default value is `false`.
+* `double_check_staging`: an optional parameter that, if set to `true`, performs
+  additional checks for staged files. This parameter can be useful for figuring
+  out the appropriate `root` for an endpoint.
 
 ## `endpoints`
 


### PR DESCRIPTION
This hack shouldn't be needed, but I can't get NMDC's filters to work for data object types at the moment. We need this to import some things into the CDM.

Also included: an extra config flag that lets us bypass or perform additional file staging checks. NMDC has quite an elaborate directory structure, which causes the DTS to flood Globus with status requests when double-checking for file availability. This diagnostic is really only useful for determining the right `root` directory for endpoints in the first place.