### PR TITLE
Separated "user" and "client" concepts for DTS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ to do:
   used to connect to the KBase Auth Server, which provides a context for
   authenticating and authorizing DTS for its basic operations
 * `DTS_KBASE_TEST_ORCID`: an [ORCID](https://orcid.org/) identifier that can be
-  used to run DTS's unit test. This identifier must match a registered ORCID ID
+  used to run DTS's unit test. This identifier must match a registered ORCID
   associated with a [KBase user account](https://narrative.kbase.us/#signup).
 * `DTS_KBASE_TEST_USER`: the KBase user associated with the ORCID specified
   by `DTS_KBASE_TEST_ORCID`.

--- a/auth/kbase_auth_server.go
+++ b/auth/kbase_auth_server.go
@@ -226,7 +226,7 @@ func (server KBaseAuthServer) kbaseUser() (kbaseUser, error) {
 		}
 	}
 	if !foundOrcid {
-		return user, fmt.Errorf("KBase Auth2: No ORCID IDs associated with this user!")
+		return user, fmt.Errorf("KBase Auth2: No ORCIDs associated with this user!")
 	}
 	return user, err
 }

--- a/auth/kbase_auth_server_test.go
+++ b/auth/kbase_auth_server_test.go
@@ -55,16 +55,16 @@ func TestInvalidToken(t *testing.T) {
 }
 
 // tests whether the authentication server can return information for the
-// user associated with the specified developer token
-func TestUserInfo(t *testing.T) {
+// client (the user associated with the specified developer token)
+func TestClient(t *testing.T) {
 	assert := assert.New(t)
 	devToken := os.Getenv("DTS_KBASE_DEV_TOKEN")
 	server, _ := NewKBaseAuthServer(devToken)
 	assert.NotNil(server)
-	userInfo, err := server.UserInfo()
+	client, err := server.Client()
 	assert.Nil(err)
 
-	assert.True(len(userInfo.Username) > 0)
-	assert.True(len(userInfo.Email) > 0)
-	assert.Equal(os.Getenv("DTS_KBASE_TEST_ORCID"), userInfo.Orcid)
+	assert.True(len(client.Username) > 0)
+	assert.True(len(client.Email) > 0)
+	assert.Equal(os.Getenv("DTS_KBASE_TEST_ORCID"), client.Orcid)
 }

--- a/auth/kbase_user_federation.go
+++ b/auth/kbase_user_federation.go
@@ -34,7 +34,7 @@ import (
 // users who have made requests to the DTS. This prevents us from having to
 // rely on a secondary data source for this information.
 
-// associates the given KBase username with the given ORCID ID
+// associates the given KBase username with the given ORCID
 func SetKBaseLocalUsernameForOrcid(orcid, username string) error {
 	if !kbaseUserFederationStarted {
 		// fire it up!
@@ -49,7 +49,7 @@ func SetKBaseLocalUsernameForOrcid(orcid, username string) error {
 	return err
 }
 
-// returns the local KBase username associated with the given ORCID ID
+// returns the local KBase username associated with the given ORCID
 func KBaseLocalUsernameForOrcid(orcid string) (string, error) {
 	if !kbaseUserFederationStarted { // no one's logged in!
 		return "", fmt.Errorf("KBase federated user table not available!")
@@ -70,8 +70,8 @@ var kbaseOrcidUserChan chan [2]string // passes (ORCIDs, username) pairs in
 var kbaseUserChan chan string         // passes usernames out
 var kbaseErrorChan chan error         // passes errors out
 
-// This goroutine maintains a mapping or ORCID IDS to local KBase users,
-// fielding requests to update and retrieve usernames by ORCID ID.
+// This goroutine maintains a mapping or ORCIDs to local KBase users,
+// fielding requests to update and retrieve usernames by ORCID.
 func kbaseUserFederation(started chan struct{}) {
 	// channels
 	kbaseOrcidChan = make(chan string)
@@ -79,7 +79,7 @@ func kbaseUserFederation(started chan struct{}) {
 	kbaseUserChan = make(chan string)
 	kbaseErrorChan = make(chan error)
 
-	// mapping of ORCID IDs to local KBase users
+	// mapping of ORCIDs to local KBase users
 	kbaseUserTable := make(map[string]string)
 
 	// we're ready

--- a/auth/user_info.go
+++ b/auth/user_info.go
@@ -21,13 +21,29 @@
 
 package auth
 
-// a record containing information about a DTS user
-type UserInfo struct {
-	// user's name (human-readable and display-friendly)
+// A record containing information about a DTS client. A DTS client is a KBase
+// user whose KBase developer token is used to authorize with the DTS.
+type Client struct {
+	// client name (human-readable and display-friendly)
 	Name string
-	// username used to access DTS
+	// KBase username used by client to access DTS
 	Username string
-	// user's email address
+	// client email address
+	Email string
+	// ORCID identifier associated with this client
+	Orcid string
+	// organization with which this client is affiliated
+	Organization string
+}
+
+// A record containing information about a DTS user using a DTS client to
+// request file transfers. A DTS user need not have a KBase developer token
+// (but should have a KBase account if they are requesting files be transferred
+// to KBase).
+type User struct {
+	// client name (human-readable and display-friendly)
+	Name string
+	// client email address
 	Email string
 	// ORCID identifier associated with this user
 	Orcid string

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -131,7 +131,7 @@ func RegisterDatabase(dbName string, createDb func(orcid string) (Database, erro
 	}
 }
 
-// creates a database proxy associated with the given ORCID ID, based on the
+// creates a database proxy associated with the given ORCID, based on the
 // configured type, or returns an existing instance
 func NewDatabase(orcid, dbName string) (Database, error) {
 	var err error

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -72,7 +72,7 @@ type StagingRequest struct {
 
 func NewDatabase(orcid string) (databases.Database, error) {
 	if orcid == "" {
-		return nil, fmt.Errorf("No ORCID ID was given")
+		return nil, fmt.Errorf("No ORCID was given")
 	}
 
 	// make sure we have a shared secret or an SSO token

--- a/databases/kbase/database.go
+++ b/databases/kbase/database.go
@@ -40,7 +40,7 @@ type Database struct {
 
 func NewDatabase(orcid string) (databases.Database, error) {
 	if orcid == "" {
-		return nil, fmt.Errorf("No ORCID ID was given")
+		return nil, fmt.Errorf("No ORCID was given")
 	}
 
 	return &Database{

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -63,7 +63,7 @@ func NewDatabase(orcid string) (databases.Database, error) {
 	if orcid == "" {
 		return nil, databases.UnauthorizedError{
 			Database: "nmdc",
-			Message:  "No ORCID ID was given",
+			Message:  "No ORCID was given",
 		}
 	}
 

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -35,13 +35,13 @@ needs to do:
   authenticating and authorizing the DTS for its basic operations. You can create
   a token [from your KBase developer account](https://kbase.github.io/kb_sdk_docs/tutorial/3_initialize.html#set-up-your-developer-credentials).
 * `DTS_KBASE_TEST_ORCID`: an [ORCID](https://orcid.org/) identifier that can be
-  used to run the DTS's unit test. This identifier must match a registered ORCID ID
+  used to run the DTS's unit test. This identifier must match a registered ORCID
   associated with a [KBase user account](https://narrative.kbase.us/#signup).
 * `DTS_KBASE_TEST_USER`: the KBase user associated with the ORCID specified
   by `DTS_KBASE_TEST_ORCID`. **NOTE: at the time of writing, KBase does not have
-  a mechanism for mapping ORCID IDs to local users, so the DTS uses a file in
-  its data directory called `kbase_users.json` consisting of a single JSON
-  object whose keys are ORCID IDs and whose values are local usernames.**
+  a mechanism for mapping ORCIDs to local users, so the DTS uses a file in its
+  data directory called `kbase_users.json` consisting of a single JSON object
+  whose keys are ORCIDs and whose values are local usernames.**
 * `DTS_GLOBUS_CLIENT_ID`: a client ID registered using the
   [Globus Developers](https://docs.globus.org/globus-connect-server/v5/use-client-credentials/#register-application)
   web interface. This ID must be registered specifically for an instance of

--- a/docs/integration/glossary.md
+++ b/docs/integration/glossary.md
@@ -43,9 +43,9 @@ We use the following terms in the DTS Integration Guide.
   level of the directory structure transferred to the destination database.
   a source database to a destination database by the DTS
 * **User federation endpoint**: An endpoint provided by your database that
-  accepts an HTTP `GET` request with an ORCID ID and produces a response
+  accepts an HTTP `GET` request with an ORCID and produces a response
   containing the corresponding username for an account within your system.
-  Read more about this endpoint in [Map ORCID IDs to Local User Accounts](local_user.md).
+  Read more about this endpoint in [Map ORCIDs to Local User Accounts](local_user.md).
 * **UUID**: A [universally unique identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier)
   used by the DTS to represent staging tasks, transfers, and other transient-
   but-possibly-long-running operations

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -77,15 +77,14 @@ The sections that follow describe each of these items in more detail.
    Additionally, your database must provide a **staging status endpoint** that
    accepts an HTTP request with a staging request UUID and produces a
    response that indicates whether the staging process has completed.
-6. **Your database can map ORCID IDs to local users within your organization.**
-   Every DTS user must authenticate with an ORCID ID to connect to the service.
-   To establish a connection between the ORCID ID and a specific user account
+6. **Your database can map ORCIDs to local users within your organization.**
+   Every DTS user must authenticate with an ORCID to connect to the service.
+   To establish a connection between the ORCID and a specific user account
    for your organization, your database must provide a **user federation
-   endpoint** that accepts an HTTP request with an ORCID ID and produces
-   a response containing the corresponding username for an account within your
-   system. This federation process allows DTS to associate a transfer operation
-   with user accounts in the organizations for the source and destination
-   databases.
+   endpoint** that accepts an HTTP request with an ORCID and produces a response
+   containing the corresponding username for an account within your system. This
+   federation process allows DTS to associate a transfer operation with user
+   accounts in the organizations for the source and destination databases.
 
 If your organization has existing services that provide similar capabilities but
 use different conventions, or if you have other technical considerations, please
@@ -99,4 +98,4 @@ best of what you have.
 * [Provide a Staging Area for Your Files](staging_area.md)
 * [Stage Your Files on Request](stage_files.md)
 * [Provide a Way to Monitor File Staging](staging_status.md)
-* [Map ORCID IDs to Local User Accounts](local_user.md)
+* [Map ORCIDs to Local User Accounts](local_user.md)

--- a/docs/integration/local_user.md
+++ b/docs/integration/local_user.md
@@ -1,27 +1,27 @@
-# Map ORCID IDs to Local User Accounts
+# Map ORCIDs to Local User Accounts
 
-The Data Transfer System (DTS) uses [ORCID IDs](https://info.orcid.org/what-is-orcid/)
+The Data Transfer System (DTS) uses [ORCIDs](https://info.orcid.org/what-is-orcid/)
 to identify individuals and organizations. In order to understand who is
 transferring what where when, your database must establish a connection between
-a user's ORCID ID and their local account on your system. This connection is a
+a user's ORCID and their local account on your system. This connection is a
 form of [federated identity management](https://en.wikipedia.org/wiki/Federated_identity),
 similar to Single Sign-On (SSO) authentication services offered by various
 platforms.
 
 ## Endpoint Recommendations
 
-Create a REST endpoint that accepts an HTTP `GET` request with a given ORCID ID
+Create a REST endpoint that accepts an HTTP `GET` request with a given ORCID
 as a path parameter or request parameter. This endpoint responds with a body
 containing a JSON object with two fields:
 
-* `orcid`: the ORCID ID passed as the query parameter
-* `username`: the local username corresponding to the given ORCID ID
+* `orcid`: the ORCID passed as the query parameter
+* `username`: the local username corresponding to the given ORCID
 
 Error codes should be used in accordance with HTTP conventions:
 
 * A successful query returns a `200 OK` status code
-* An improperly-formed ORCID ID should result in a `400 Bad Request` status code
-* An ORCID ID that does not correspond to a local user should produce `404 Not Found`
+* An improperly-formed ORCID should result in a `400 Bad Request` status code
+* An ORCID that does not correspond to a local user should produce `404 Not Found`
 
 ### Example
 
@@ -48,7 +48,7 @@ This produces a responѕe with a `200 OK` status code with the body
 
 This particular feature is actually not yet supported by KBase, so the DTS
 prototype uses a locally-stored JSON file containing an object whose
-field names are ORCID IDs and whose values are usernames for the corresponding
+field names are ORCIDs and whose values are usernames for the corresponding
 KBase users.
 
 * Example: current workaround (to be updated when JDP and KBase support this!)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
     - 'Provide a Staging Area for Your Files': 'integration/staging_area.md'
     - 'Stage Your Files on Request': 'integration/stage_files.md'
     - 'Provide a Way to Monitor File Staging': 'integration/staging_status.md'
-    - 'Map ORCID IDs to Local User Accounts': 'integration/local_user.md'
+    - 'Map ORCIDs to Local User Accounts': 'integration/local_user.md'
     - 'Glossary': 'integration/glossary.md'
   - 'Developer Guide':
     - 'Overview': 'developer/index.md'

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -45,6 +45,8 @@ type FileMetadataResponse struct {
 
 // a request for a file transfer (POST)
 type TransferRequest struct {
+	// user ORCID
+	Orcid string `json:"orcid" example:"0000-0002-9227-8514" doc:"ORCID for user requesting transfer"`
 	// name of source database
 	Source string `json:"source" example:"jdp" doc:"source database identifier"`
 	// identifiers for files to be transferred

--- a/tasks/subtask.go
+++ b/tasks/subtask.go
@@ -49,7 +49,7 @@ type transferSubtask struct {
 	StagingStatus       databases.StagingStatus // staging status
 	Transfer            uuid.NullUUID           // file transfer UUID (if any)
 	TransferStatus      TransferStatus          // status of file transfer operation
-	UserInfo            auth.UserInfo           // info about user requesting transfer
+	Client              auth.Client             // info about client used for transfer
 }
 
 func (subtask *transferSubtask) start() error {
@@ -68,7 +68,7 @@ func (subtask *transferSubtask) start() error {
 	} else {
 		// tell the source DB to stage the files, stash the task, and return
 		// its new ID
-		source, err := databases.NewDatabase(subtask.UserInfo.Orcid, subtask.Source)
+		source, err := databases.NewDatabase(subtask.Client.Orcid, subtask.Source)
 		if err != nil {
 			return err
 		}
@@ -106,7 +106,7 @@ func (subtask *transferSubtask) update() error {
 // checks whether files for a subtask are finished staging and, if so,
 // initiates the transfer process
 func (subtask *transferSubtask) checkStaging() error {
-	source, err := databases.NewDatabase(subtask.UserInfo.Orcid, subtask.Source)
+	source, err := databases.NewDatabase(subtask.Client.Orcid, subtask.Source)
 	if err != nil {
 		return err
 	}

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -168,8 +168,10 @@ type Specification struct {
 	// the name of source database from which files are transferred (as specified
 	// in the DTS config file)
 	Source string
+	// information about the client accessing the DTS
+	Client auth.Client
 	// information about the user requesting the task
-	UserInfo auth.UserInfo
+	User auth.User
 }
 
 // Creates a new transfer task associated with the user with the specified Orcid
@@ -186,18 +188,19 @@ func Create(spec Specification) (uuid.UUID, error) {
 
 	// verify that we can fetch the task's source and destination databases
 	// without incident
-	_, err := databases.NewDatabase(spec.UserInfo.Orcid, spec.Source)
+	_, err := databases.NewDatabase(spec.Client.Orcid, spec.Source)
 	if err != nil {
 		return taskId, err
 	}
-	_, err = databases.NewDatabase(spec.UserInfo.Orcid, spec.Destination)
+	_, err = databases.NewDatabase(spec.Client.Orcid, spec.Destination)
 	if err != nil {
 		return taskId, err
 	}
 
 	// create a new task and send it along for processing
 	taskChannels.CreateTask <- transferTask{
-		UserInfo:     spec.UserInfo,
+		Client:       spec.Client,
+		User:         spec.User,
 		Source:       spec.Source,
 		Destination:  spec.Destination,
 		FileIds:      spec.FileIds,
@@ -350,6 +353,10 @@ func processTasks() {
 			returnTaskIdChan <- newTask.Id
 			slog.Info(fmt.Sprintf("Created new transfer task %s (%d file(s) requested)",
 				newTask.Id.String(), len(newTask.FileIds)))
+			// FIXME: this can be removed when we remove the user -> client ORCID fallback
+			if newTask.User.Orcid == newTask.Client.Orcid {
+				slog.Debug(fmt.Sprintf("Task %s: No user ORCID specified, using client ORCID", newTask.Id.String()))
+			}
 		case taskId := <-cancelTaskChan: // Cancel() called
 			if task, found := tasks[taskId]; found {
 				slog.Info(fmt.Sprintf("Task %s: received cancellation request", taskId.String()))

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -119,7 +119,11 @@ func (t *SerialTests) TestCreateTask() {
 
 	// queue up a transfer task between two phony databases
 	taskId, err := Create(Specification{
-		UserInfo: auth.UserInfo{
+		Client: auth.Client{
+			Name:  "Joe-bob",
+			Orcid: "1234-5678-9012-3456",
+		},
+		User: auth.User{
 			Name:  "Joe-bob",
 			Orcid: "1234-5678-9012-3456",
 		},
@@ -182,7 +186,11 @@ func (t *SerialTests) TestCancelTask() {
 
 	// queue up a transfer task between two phony databases
 	taskId, err := Create(Specification{
-		UserInfo: auth.UserInfo{
+		Client: auth.Client{
+			Name:  "Joe-bob",
+			Orcid: "1234-5678-9012-3456",
+		},
+		User: auth.User{
 			Name:  "Joe-bob",
 			Orcid: "1234-5678-9012-3456",
 		},
@@ -228,7 +236,11 @@ func (t *SerialTests) TestStopAndRestart() {
 	taskIds := make([]uuid.UUID, numTasks)
 	for i := 0; i < numTasks; i++ {
 		taskId, _ := Create(Specification{
-			UserInfo: auth.UserInfo{
+			Client: auth.Client{
+				Name:  "Joe-bob",
+				Orcid: "1234-5678-9012-3456",
+			},
+			User: auth.User{
 				Name:  "Joe-bob",
 				Orcid: "1234-5678-9012-3456",
 			},


### PR DESCRIPTION
This PR breaks our `auth.UserInfo` into `auth.User` and `auth.Client` types in order to distinguish between the rights/privileges of a DTS client used by one or more users, and each user. This allows us to easily associate a specific user (via ORCID) with each transfer request, and allows us to retain client-specific data (like active database proxies) that aren't tied to individual users.

For now, if no user ORCID is specified by a transfer request, the DTS falls back to the client's ORCID. We'll remove this fallback when existing services have user-specific transfer ORCIDs in place within transfer requests.

Closes #81