### PR TITLE
Added a secure-by-default HTTP client for databases.

### DIFF
--- a/databases/errors.go
+++ b/databases/errors.go
@@ -124,3 +124,14 @@ type ResourceEndpointNotFoundError struct {
 func (e ResourceEndpointNotFoundError) Error() string {
 	return fmt.Sprintf("Can't determine endpoint for resource '%s' in database '%s'", e.ResourceId, e.Database)
 }
+
+// this error type is emitted if an endpoint redirects an HTTPS request to an
+// HTTP endpoint (it's NUTS that this can happen!)
+type DowngradedRedirectError struct {
+	Endpoint string
+}
+
+func (e DowngradedRedirectError) Error() string {
+	return fmt.Sprintf("The endpoint %s is attempting to downgrade an HTTPS request to HTTP",
+		e.Endpoint)
+}

--- a/databases/http.go
+++ b/databases/http.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package databases
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/StalkR/hsts"
+)
+
+// Here's a secure HTTP client that can be used to connect to databases. It
+// sets a reasonable timeout and enables HTTP Strict Transport Security (HSTS).
+func SecureHttpClient() http.Client {
+	client := http.Client{
+		Timeout: time.Second * 10,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.URL.Scheme == "http" {
+				return DowngradedRedirectError{
+					Endpoint: fmt.Sprintf("%s%s", req.URL.Host, req.URL.Path),
+				}
+			}
+			return http.ErrUseLastResponse
+		},
+	}
+	client.Transport = hsts.New(client.Transport) // enable HSTS
+	return client
+}

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -92,7 +92,11 @@ func NewDatabase(orcid string) (databases.Database, error) {
 		}
 	}
 
+	// NOTE: we can't enable HSTS for JDP requests at this time, because the
+	// NOTE: server doesn't seem to support it. Maybe raise this issue with the
+	// NOTE: team?
 	return &Database{
+		//Client:          databases.SecureHttpClient(),
 		Id:              "jdp",
 		Orcid:           orcid,
 		Secret:          secret,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 toolchain go1.23.1
 
 require (
+	github.com/StalkR/hsts v1.0.3
 	github.com/danielgtaylor/huma/v2 v2.27.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/StalkR/hsts v1.0.3 h1:3dAfhmsMFtLZaFGjsU/XNAvSD44yXeOnL31SLXyFRa8=
+github.com/StalkR/hsts v1.0.3/go.mod h1:kde3l3eCEeFRVvA8FX524o9Z4H8tTtAo2VjdvMjji7Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danielgtaylor/huma/v2 v2.27.0 h1:yxgJ8GqYqKeXw/EnQ4ZNc2NBpmn49AlhxL2+ksSXjUI=
 github.com/danielgtaylor/huma/v2 v2.27.0/go.mod h1:NbSFXRoOMh3BVmiLJQ9EbUpnPas7D9BeOxF/pZBAGa0=

--- a/vendor/github.com/StalkR/hsts/.gitignore
+++ b/vendor/github.com/StalkR/hsts/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/StalkR/hsts/LICENSE
+++ b/vendor/github.com/StalkR/hsts/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/StalkR/hsts/README.md
+++ b/vendor/github.com/StalkR/hsts/README.md
@@ -1,0 +1,42 @@
+# HTTP Strict Transport Security (HSTS)
+
+[![Build Status][1]][2] [![Godoc][3]][4]
+
+http [RoundTripper][8] implementing [HTTP Strict Transport Security][6]
+([RFC 6797][7]) with sites preloaded from [Chromium][9] using `go generate`.
+
+Install:
+
+	go get github.com/StalkR/hsts
+
+Usage (taken from the example in [godoc][4]):
+
+	client := http.DefaultClient
+	// Wrap around the client's transport to add HSTS support.
+	client.Transport = hsts.New(client.Transport)
+
+	// Assuming example.com has set up HSTS, we learn it at the first HTTPS request.
+	resp, err := client.Get("https://example.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// So that any following request made in insecure HTTP would go in HTTPS.
+	resp, err = client.Get("http://example.com") // will become HTTPS
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+Bugs, comments, questions: create a [new issue][5].
+
+[1]: https://github.com/StalkR/hsts/actions/workflows/build.yml/badge.svg
+[2]: https://github.com/StalkR/hsts/actions/workflows/build.yml
+[3]: https://godoc.org/github.com/StalkR/hsts?status.png
+[4]: https://godoc.org/github.com/StalkR/hsts
+[5]: https://github.com/StalkR/hsts/issues/new
+[6]: https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
+[7]: https://tools.ietf.org/html/rfc6797
+[8]: https://godoc.org/net/http#RoundTripper
+[9]: https://www.chromium.org/hsts

--- a/vendor/github.com/StalkR/hsts/directives.go
+++ b/vendor/github.com/StalkR/hsts/directives.go
@@ -1,0 +1,94 @@
+package hsts
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// A directive stores HSTS state information for a given host.
+type directive struct {
+	received          time.Time
+	maxAge            time.Duration
+	includeSubDomains bool
+}
+
+// parse parses a Strict-Transport-Security header as specified in section 6.1.
+// Section 6.1 requirements 4 & 5 say to ignore non-conformance so no error is returned.
+func parse(header string) *directive {
+	// Use a map as a set to check for unicity (6.1 requirement 2).
+	directives := make(map[string]struct{})
+
+	// Known directives.
+	var maxAge time.Duration
+	var includeSubDomains bool
+
+	// Section 6.1 defines the grammar as:
+	//   Strict-Transport-Security = [ directive ]  *( ";" [ directive ] )
+	//   directive                 = directive-name [ "=" directive-value ]
+	//   directive-name            = token
+	//   directive-value           = token | quoted-string
+	for _, directive := range strings.Split(header, ";") {
+		var name, value string
+
+		// Grammar says directive value is optional.
+		if strings.Contains(directive, "=") {
+			nv := strings.SplitN(directive, "=", 2)
+			name = nv[0]
+			value = nv[1]
+		} else {
+			name = directive
+		}
+
+		name = strings.TrimSpace(name)
+		value = strings.TrimSpace(value)
+
+		name = strings.ToLower(name) // Section 6.1 requirement 3.
+
+		if _, ok := directives[name]; ok {
+			// Section 6.1 requirement 2 says directives must appear only once
+			// and requirements 4 & 5 say to ignore directives that do not conform
+			// so we ignore duplicates.
+			continue
+		}
+		directives[name] = struct{}{}
+
+		// Grammar says directive value can be be a quoted string.
+		if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+			v, err := strconv.Unquote(value)
+			if err != nil {
+				// Section 6.1 requirement 4 says to ignore non-conforming values.
+				continue
+			}
+			value = v
+		}
+
+		switch name { // Note it's been lowercased
+		case "max-age":
+			secs, err := strconv.Atoi(value)
+			if err != nil {
+				// Section 6.1 requirement 4 says to ignore non-conforming values.
+				continue
+			}
+			maxAge = time.Duration(secs) * time.Second
+		case "includesubdomains":
+			if value != "" {
+				// Section 6.1 requirement 4 says to ignore non-conforming values.
+				continue
+			}
+			includeSubDomains = true
+		}
+	}
+
+	// Section 6.1.1 says the max-age directive is required and section 6.1
+	// requirements 4 & 5 say to ignore non-conformance, so we ignore all of it.
+	if _, ok := directives["max-age"]; !ok {
+		return nil
+	}
+
+	return &directive{
+		received:          time.Now(),
+		maxAge:            maxAge,
+		includeSubDomains: includeSubDomains,
+	}
+}

--- a/vendor/github.com/StalkR/hsts/transport.go
+++ b/vendor/github.com/StalkR/hsts/transport.go
@@ -1,0 +1,148 @@
+/*
+Package hsts implements a RoundTripper that supports HTTP Strict Transport Security.
+
+It comes preloaded with sites from Chromium (https://www.chromium.org/hsts),
+updated with go generate.
+*/
+package hsts
+
+//go:generate go run generate/preload.go -p hsts -v preload -o preload.go
+//go:generate gofmt -w preload.go
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Transport implements a RoundTripper adding HSTS to an existing RoundTripper.
+type Transport struct {
+	wrap  http.RoundTripper
+	m     sync.Mutex            // protects state
+	state map[string]*directive // key is host (RFC section 8.3)
+}
+
+// New wraps around a RoundTripper transport to add HTTP Strict Transport Security (HSTS).
+// It starts preloaded with Chromium's list (https://www.chromium.org/hsts).
+// Just like an http.Client if transport is nil, http.DefaultTransport is used.
+func New(transport http.RoundTripper) *Transport {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	state := make(map[string]*directive)
+	for host, includeSubDomains := range preload {
+		state[host] = &directive{includeSubDomains: includeSubDomains}
+	}
+	return &Transport{
+		wrap:  transport,
+		state: state,
+	}
+}
+
+// RoundTrip executes a single HTTP transaction and adds support for HSTS.
+// It is safe for concurrent use by multiple goroutines.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if u, ok := t.needsUpgrade(req); ok {
+		code := http.StatusTemporaryRedirect
+		return reply(req, fmt.Sprintf("HTTP/1.1 %d %s\r\nLocation: %s\r\n\r\n",
+			code, http.StatusText(code), u.String()))
+	}
+	resp, err := t.wrap.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	t.processResponse(resp)
+	return resp, nil
+}
+
+func reply(req *http.Request, s string) (*http.Response, error) {
+	return http.ReadResponse(bufio.NewReader(strings.NewReader(s)), req)
+}
+
+// needsUpgrade tells whether a request is HTTP and needs upgrading to HTTPS.
+// If it needs upgrading, the destination URL to redirect to is returned.
+func (t *Transport) needsUpgrade(req *http.Request) (*url.URL, bool) {
+	if req.URL.Scheme != "http" {
+		return nil, false
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	// TODO(StalkR): check host isn't an IP-literal or IPv4 (section 8.3.3).
+
+	host := req.URL.Host
+	d := t.find(host, true)
+	if d == nil { // not found
+		return nil, false
+	}
+
+	// Preloaded sites do not expire; dynamic entries do.
+	preloaded := d.received.IsZero()
+	if !preloaded && time.Now().After(d.received.Add(d.maxAge)) {
+		delete(t.state, host)
+		return nil, false
+	}
+
+	u := *req.URL // copy to avoid modifying the request URL
+
+	// Section 8.3 step 5a says to replace the http scheme with https.
+	if u.Scheme == "http" {
+		u.Scheme = "https"
+	}
+	// Section 8.3 step 5b says to replace explicit 80 with 443.
+	if strings.Contains(u.Host, ":") {
+		hp := strings.SplitN(u.Host, ":", 2)
+		if port, err := strconv.Atoi(hp[1]); err == nil {
+			if port == 80 {
+				port = 443
+			}
+			u.Host = fmt.Sprintf("%s:%d", hp[0], port)
+		}
+	}
+	// Section 8.3 step 5c and 5d says to preserve otherwise.
+
+	return &u, true
+}
+
+// find finds a host including subdomains. Lock must be taken already.
+func (t *Transport) find(host string, exact bool) *directive {
+	d, ok := t.state[host]
+	if ok && (exact || d.includeSubDomains) {
+		return d
+	}
+	i := strings.Index(host, ".")
+	if i == -1 {
+		return nil
+	}
+	return t.find(host[i+1:], false)
+}
+
+// processResponse looks into an HTTP response to see if HSTS state needs to be updated.
+func (t *Transport) processResponse(resp *http.Response) {
+	header := resp.Header.Get("Strict-Transport-Security")
+	if header == "" {
+		return // missing
+	}
+	d := parse(header)
+	if d == nil {
+		return // invalid
+	}
+	t.add(resp.Request.URL.Host, d)
+}
+
+// Add adds a host in the Strict-Transport-Security state.
+func (t *Transport) add(host string, d *directive) {
+	t.m.Lock()
+	defer t.m.Unlock()
+	if d.maxAge == 0 { // Section 6.1.1 says 0 signals the UA to forget about it.
+		delete(t.state, host)
+		return
+	}
+	t.state[host] = d
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,6 @@
+# github.com/StalkR/hsts v1.0.3
+## explicit; go 1.14
+github.com/StalkR/hsts
 # github.com/danielgtaylor/huma/v2 v2.27.0
 ## explicit; go 1.22
 github.com/danielgtaylor/huma/v2


### PR DESCRIPTION
This client is used for NMDC but not JDP, since the latter doesn't (yet) support HTTP Strict Transport Security (HSTS). Probably a good idea to encourage them to support this feature in the near future.