### PR TITLE
Replacing the DTS client ORCID with operation-specific user ORCIDs

### DIFF
--- a/databases/databases_test.go
+++ b/databases/databases_test.go
@@ -1,7 +1,6 @@
 package databases
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +8,7 @@ import (
 
 func TestInvalidDatabase(t *testing.T) {
 	assert := assert.New(t)
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	bbDb, err := NewDatabase(orcid, "booga booga")
+	bbDb, err := NewDatabase("booga booga")
 	assert.Nil(bbDb, "Invalid database should not be created")
 	assert.NotNil(err, "Invalid database creation did not report an error")
 }

--- a/databases/errors.go
+++ b/databases/errors.go
@@ -96,6 +96,16 @@ func (e InvalidResourceEndpointError) Error() string {
 		e.ResourceId, e.Database, e.Endpoint)
 }
 
+// this error type is returned when an operation requires a user ORCID but none
+// is provided
+type MissingOrcidError struct {
+	Database string
+}
+
+func (e MissingOrcidError) Error() string {
+	return fmt.Sprintf("Missing user ORCID for request to database '%s'", e.Database)
+}
+
 // this error type is returned when a resource is requested for which the requester
 // does not have permission
 type PermissionDeniedError struct {

--- a/databases/jdp/database_test.go
+++ b/databases/jdp/database_test.go
@@ -43,25 +43,16 @@ func breakdown() {
 
 func TestNewDatabase(t *testing.T) {
 	assert := assert.New(t)
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	jdpDb, err := NewDatabase(orcid)
+	jdpDb, err := NewDatabase()
 	assert.NotNil(jdpDb, "JDP database not created")
 	assert.Nil(err, "JDP database creation encountered an error")
 }
 
-func TestNewDatabaseWithoutOrcid(t *testing.T) {
-	assert := assert.New(t)
-	jdpDb, err := NewDatabase("")
-	assert.Nil(jdpDb, "Invalid JDP database somehow created")
-	assert.NotNil(err, "JDP database creation without ORCID encountered no error")
-}
-
 func TestNewDatabaseWithoutJDPSharedSecret(t *testing.T) {
 	assert := assert.New(t)
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 	jdpSecret := os.Getenv("DTS_JDP_SECRET")
 	os.Unsetenv("DTS_JDP_SECRET")
-	jdpDb, err := NewDatabase(orcid)
+	jdpDb, err := NewDatabase()
 	os.Setenv("DTS_JDP_SECRET", jdpSecret)
 	assert.Nil(jdpDb, "JDP database somehow created without shared secret available")
 	assert.NotNil(err, "JDP database creation without shared secret encountered no error")
@@ -70,7 +61,7 @@ func TestNewDatabaseWithoutJDPSharedSecret(t *testing.T) {
 func TestSearch(t *testing.T) {
 	assert := assert.New(t)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, _ := NewDatabase(orcid)
+	db, _ := NewDatabase()
 	params := databases.SearchParameters{
 		Query: "prochlorococcus",
 		Pagination: struct {
@@ -80,7 +71,7 @@ func TestSearch(t *testing.T) {
 			MaxNum: 50,
 		},
 	}
-	results, err := db.Search(params)
+	results, err := db.Search(orcid, params)
 	assert.True(len(results.Resources) > 0, "JDP search query returned no results")
 	assert.Nil(err, "JDP search query encountered an error")
 }
@@ -88,16 +79,16 @@ func TestSearch(t *testing.T) {
 func TestResources(t *testing.T) {
 	assert := assert.New(t)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, _ := NewDatabase(orcid)
+	db, _ := NewDatabase()
 	params := databases.SearchParameters{
 		Query: "prochlorococcus",
 	}
-	results, _ := db.Search(params)
+	results, _ := db.Search(orcid, params)
 	fileIds := make([]string, len(results.Resources))
 	for i, res := range results.Resources {
 		fileIds[i] = res.Id
 	}
-	resources, err := db.Resources(fileIds[:10])
+	resources, err := db.Resources(orcid, fileIds[:10])
 	assert.Nil(err, "JDP resource query encountered an error")
 	assert.Equal(10, len(resources),
 		"JDP resource query didn't return requested number of results")

--- a/databases/kbase/database.go
+++ b/databases/kbase/database.go
@@ -33,8 +33,6 @@ import (
 // file database appropriate for handling KBase searches and transfers
 // (implements the databases.Database interface)
 type Database struct {
-	// database identifier
-	Id string
 }
 
 func NewDatabase() (databases.Database, error) {
@@ -43,9 +41,7 @@ func NewDatabase() (databases.Database, error) {
 		return nil, err
 	}
 
-	return &Database{
-		Id: "kbase",
-	}, nil
+	return &Database{}, nil
 }
 
 func (db *Database) SpecificSearchParameters() map[string]interface{} {

--- a/databases/kbase/database.go
+++ b/databases/kbase/database.go
@@ -37,11 +37,7 @@ type Database struct {
 	Id string
 }
 
-func NewDatabase(orcid string) (databases.Database, error) {
-	if orcid == "" {
-		return nil, fmt.Errorf("No ORCID was given")
-	}
-
+func NewDatabase() (databases.Database, error) {
 	err := startUserFederation()
 	if err != nil {
 		return nil, err
@@ -56,17 +52,17 @@ func (db *Database) SpecificSearchParameters() map[string]interface{} {
 	return nil
 }
 
-func (db *Database) Search(params databases.SearchParameters) (databases.SearchResults, error) {
+func (db *Database) Search(orcid string, params databases.SearchParameters) (databases.SearchResults, error) {
 	err := fmt.Errorf("Search not implemented for kbase database!")
 	return databases.SearchResults{}, err
 }
 
-func (db *Database) Resources(fileIds []string) ([]frictionless.DataResource, error) {
+func (db *Database) Resources(orcid string, fileIds []string) ([]frictionless.DataResource, error) {
 	err := fmt.Errorf("Resources not implemented for kbase database!")
 	return nil, err
 }
 
-func (db *Database) StageFiles(fileIds []string) (uuid.UUID, error) {
+func (db *Database) StageFiles(orcid string, fileIds []string) (uuid.UUID, error) {
 	err := fmt.Errorf("StageFiles not implemented for kbase database!")
 	return uuid.UUID{}, err
 }

--- a/databases/kbase/database_test.go
+++ b/databases/kbase/database_test.go
@@ -30,7 +30,6 @@ func TestMain(m *testing.M) {
 func TestRunner(t *testing.T) {
 	tester := SerialTests{Test: t}
 	tester.TestNewDatabase()
-	tester.TestNewDatabaseWithoutOrcid()
 	tester.TestUserFederation()
 	tester.TestSearch()
 	tester.TestResources()
@@ -39,28 +38,19 @@ func TestRunner(t *testing.T) {
 
 func (t *SerialTests) TestNewDatabase() {
 	assert := assert.New(t.Test)
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, err := NewDatabase(orcid)
+	db, err := NewDatabase()
 	assert.NotNil(db, "KBase database not created")
 	assert.Nil(err, "KBase database creation encountered an error")
 }
 
-func (t *SerialTests) TestNewDatabaseWithoutOrcid() {
-	assert := assert.New(t.Test)
-	db, err := NewDatabase("")
-	assert.Nil(db, "Invalid KBase database somehow created")
-	assert.NotNil(err, "KBase database creation without ORCID encountered no error")
-}
-
 func (t *SerialTests) TestUserFederation() {
 	assert := assert.New(t.Test)
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 
 	// make sure we can create a db with good user tables
 	for i := range goodUserTables {
 		err := copyDataFile(fmt.Sprintf("good_user_table_%d.csv", i), kbaseUserTableFile)
 		assert.Nil(err, "Couldn't copy good_user_table_%d.csv into place.")
-		db, err := NewDatabase(orcid)
+		db, err := NewDatabase()
 		assert.NotNil(db, fmt.Sprintf("KBase database not created with good_user_table_%d", i))
 		assert.Nil(err, "KBase database creation encountered an error")
 		err = stopUserFederation()
@@ -71,7 +61,7 @@ func (t *SerialTests) TestUserFederation() {
 	for i := range badUserTables {
 		err := copyDataFile(fmt.Sprintf("bad_user_table_%d.csv", i), kbaseUserTableFile)
 		assert.Nil(err, "Couldn't copy bad_user_table_%d.csv into place.")
-		db, err := NewDatabase(orcid)
+		db, err := NewDatabase()
 		assert.Nil(db, fmt.Sprintf("KBase database created with bad_user_table_%d.csv", i))
 		assert.NotNil(err, "KBase database creation with bad user table didn't encounter an error")
 		err = stopUserFederation()
@@ -85,7 +75,7 @@ func (t *SerialTests) TestUserFederation() {
 func (t *SerialTests) TestSearch() {
 	assert := assert.New(t.Test)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, _ := NewDatabase(orcid)
+	db, _ := NewDatabase()
 	params := databases.SearchParameters{
 		Query: "prochlorococcus",
 		Pagination: struct {
@@ -95,22 +85,21 @@ func (t *SerialTests) TestSearch() {
 			MaxNum: 50,
 		},
 	}
-	_, err := db.Search(params)
+	_, err := db.Search(orcid, params)
 	assert.NotNil(err, "Search not implemented for kbase database!")
 }
 
 func (t *SerialTests) TestResources() {
 	assert := assert.New(t.Test)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, _ := NewDatabase(orcid)
-	_, err := db.Resources(nil)
+	db, _ := NewDatabase()
+	_, err := db.Resources(orcid, nil)
 	assert.NotNil(err, "Resources not implemented for kbase database!")
 }
 
 func (t *SerialTests) TestLocalUser() {
 	assert := assert.New(t.Test)
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, _ := NewDatabase(orcid)
+	db, _ := NewDatabase()
 	username, err := db.LocalUser("1234-5678-9101-112X")
 	assert.Nil(err)
 	assert.Equal("Alice", username)

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -47,8 +47,6 @@ import (
 // file database appropriate for handling searches and transfers
 // (implements the databases.Database interface)
 type Database struct {
-	// database identifier
-	Id string
 	// HTTP client that caches queries
 	Client http.Client
 	// authorization info
@@ -102,7 +100,6 @@ func NewDatabase() (databases.Database, error) {
 			"https://data.microbiomedata.org/data/": nerscEndpoint,
 			"https://nmdcdemo.emsl.pnnl.gov/":       emslEndpoint,
 		},
-		Id: "nmdc",
 	}
 
 	// get an API access token

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -71,29 +71,21 @@ func breakdown() {
 
 func TestNewDatabase(t *testing.T) {
 	assert := assert.New(t)
-	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, err := NewDatabase(orcid)
+	db, err := NewDatabase()
 	assert.NotNil(db, "NMDC database not created")
 	assert.Nil(err, "NMDC database creation encountered an error")
-}
-
-func TestNewDatabaseWithoutOrcid(t *testing.T) {
-	assert := assert.New(t)
-	db, err := NewDatabase("")
-	assert.Nil(db, "Invalid NMDC database somehow created")
-	assert.NotNil(err, "NMDC database creation without ORCID encountered no error")
 }
 
 func TestSearch(t *testing.T) {
 	assert := assert.New(t)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, _ := NewDatabase(orcid)
+	db, _ := NewDatabase()
 
 	params := databases.SearchParameters{
 		Query:    "",
 		Specific: nmdcSearchParams,
 	}
-	results, err := db.Search(params)
+	results, err := db.Search(orcid, params)
 	assert.True(len(results.Resources) > 0, "NMDC search query returned no results")
 	assert.Nil(err, "NMDC search query encountered an error")
 }
@@ -101,17 +93,17 @@ func TestSearch(t *testing.T) {
 func TestResources(t *testing.T) {
 	assert := assert.New(t)
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
-	db, _ := NewDatabase(orcid)
+	db, _ := NewDatabase()
 	params := databases.SearchParameters{
 		Query:    "",
 		Specific: nmdcSearchParams,
 	}
-	results, _ := db.Search(params)
+	results, _ := db.Search(orcid, params)
 	fileIds := make([]string, len(results.Resources))
 	for i, res := range results.Resources {
 		fileIds[i] = res.Id
 	}
-	resources, err := db.Resources(fileIds[:10])
+	resources, err := db.Resources(orcid, fileIds[:10])
 	assert.Nil(err, "NMDC resource query encountered an error")
 	assert.Equal(10, len(resources),
 		"NMDC resource query didn't return requested number of results")

--- a/dtstest/dtstest.go
+++ b/dtstest/dtstest.go
@@ -201,7 +201,7 @@ type Database struct {
 // Registers a database test fixture with the given name in the configuration.
 func RegisterDatabase(databaseName string, resources map[string]frictionless.DataResource) error {
 	slog.Debug(fmt.Sprintf("Registering test database %s...", databaseName))
-	newDatabaseFunc := func(orcid string) (databases.Database, error) {
+	newDatabaseFunc := func() (databases.Database, error) {
 		endpoint, err := endpoints.NewEndpoint(config.Databases[databaseName].Endpoint)
 		if err != nil {
 			return nil, err
@@ -226,7 +226,7 @@ func (db Database) SpecificSearchParameters() map[string]interface{} {
 	}
 }
 
-func (db *Database) Search(params databases.SearchParameters) (databases.SearchResults, error) {
+func (db *Database) Search(orcid string, params databases.SearchParameters) (databases.SearchResults, error) {
 	// look for file IDs in the search query
 	results := databases.SearchResults{
 		Resources: make([]frictionless.DataResource, 0),
@@ -239,7 +239,7 @@ func (db *Database) Search(params databases.SearchParameters) (databases.SearchR
 	return results, nil
 }
 
-func (db *Database) Resources(fileIds []string) ([]frictionless.DataResource, error) {
+func (db *Database) Resources(orcid string, fileIds []string) ([]frictionless.DataResource, error) {
 	resources := make([]frictionless.DataResource, 0)
 	for _, fileId := range fileIds {
 		if resource, found := db.resources[fileId]; found {
@@ -249,7 +249,7 @@ func (db *Database) Resources(fileIds []string) ([]frictionless.DataResource, er
 	return resources, nil
 }
 
-func (db *Database) StageFiles(fileIds []string) (uuid.UUID, error) {
+func (db *Database) StageFiles(orcid string, fileIds []string) (uuid.UUID, error) {
 	id := uuid.New()
 	db.Staging[id] = stagingRequest{
 		FileIds: fileIds,

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -448,9 +448,11 @@ func TestFetchJdpMetadata(t *testing.T) {
 // creates a transfer from source -> destination1
 func TestCreateTransfer(t *testing.T) {
 	assert := assert.New(t)
+	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 
 	// request a transfer of file1.txt, file2.txt, and file3.txt
 	payload, err := json.Marshal(TransferRequest{
+		Orcid:       orcid,
 		Source:      "source",
 		FileIds:     []string{"1", "2", "3"},
 		Destination: "destination1",
@@ -505,9 +507,11 @@ func TestCreateTransfer(t *testing.T) {
 // creates a transfer from source -> destination2 and then cancels it
 func TestCreateAndCancelTransfer(t *testing.T) {
 	assert := assert.New(t)
+	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 
 	// request a transfer of file1.txt, file2.txt, and file3.txt
 	payload, err := json.Marshal(TransferRequest{
+		Orcid:       orcid,
 		Source:      "source",
 		FileIds:     []string{"1", "2", "3"},
 		Destination: "destination2",

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -54,7 +54,6 @@ type transferTask struct {
 	Source            string            // name of source database (in config)
 	Status            TransferStatus    // status of file transfer operation
 	Subtasks          []transferSubtask // list of constituent file transfer subtasks
-	Client            auth.Client       // info about the DTS client used for this task
 	User              auth.User         // info about user requesting transfer
 }
 
@@ -69,13 +68,13 @@ func payloadSize(resources []DataResource) float64 {
 
 // starts a task going, initiating staging if needed
 func (task *transferTask) start() error {
-	source, err := databases.NewDatabase(task.Client.Orcid, task.Source)
+	source, err := databases.NewDatabase(task.Source)
 	if err != nil {
 		return err
 	}
 
 	// resolve resource data using file IDs
-	resources, err := source.Resources(task.FileIds)
+	resources, err := source.Resources(task.User.Orcid, task.FileIds)
 	if err != nil {
 		return err
 	}
@@ -115,7 +114,7 @@ func (task *transferTask) start() error {
 	destinationEndpoint := config.Databases[task.Destination].Endpoint
 
 	// construct a destination folder name
-	destination, err := databases.NewDatabase(task.Client.Orcid, task.Destination)
+	destination, err := databases.NewDatabase(task.Destination)
 	if err != nil {
 		return err
 	}
@@ -151,7 +150,7 @@ func (task *transferTask) start() error {
 			Resources:           resourcesForEndpoint,
 			Source:              task.Source,
 			SourceEndpoint:      sourceEndpoint,
-			Client:              task.Client,
+			User:                task.User,
 		})
 	}
 

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -119,10 +119,6 @@ func (t *SerialTests) TestCreateTask() {
 
 	// queue up a transfer task between two phony databases
 	taskId, err := Create(Specification{
-		Client: auth.Client{
-			Name:  "Joe-bob",
-			Orcid: "1234-5678-9012-3456",
-		},
 		User: auth.User{
 			Name:  "Joe-bob",
 			Orcid: "1234-5678-9012-3456",
@@ -186,10 +182,6 @@ func (t *SerialTests) TestCancelTask() {
 
 	// queue up a transfer task between two phony databases
 	taskId, err := Create(Specification{
-		Client: auth.Client{
-			Name:  "Joe-bob",
-			Orcid: "1234-5678-9012-3456",
-		},
 		User: auth.User{
 			Name:  "Joe-bob",
 			Orcid: "1234-5678-9012-3456",
@@ -236,10 +228,6 @@ func (t *SerialTests) TestStopAndRestart() {
 	taskIds := make([]uuid.UUID, numTasks)
 	for i := 0; i < numTasks; i++ {
 		taskId, _ := Create(Specification{
-			Client: auth.Client{
-				Name:  "Joe-bob",
-				Orcid: "1234-5678-9012-3456",
-			},
 			User: auth.User{
 				Name:  "Joe-bob",
 				Orcid: "1234-5678-9012-3456",


### PR DESCRIPTION
This PR adds an `orcid` parameter to search and metadata endpoints, falling back on the DTS client's ORCID if the parameter is not supplied. It also makes a user ORCID required for a transfer request, since Ken's service already satisfies this condition.