### PR TITLE
Fixed JDP resource metadata retrieval for manifests

### DIFF
--- a/databases/jdp/file.go
+++ b/databases/jdp/file.go
@@ -63,7 +63,7 @@ type File struct {
 	DataGroup string `json:"data_group"`
 }
 
-// this type represents metadata associated with a jdpFile
+// this type represents metadata associated with a File ^^^
 type Metadata struct {
 	// proposal info
 	Proposal struct {


### PR DESCRIPTION
The per-file metadata returned by the JDP endpoint we use to populate a DTS manifest is different from the per-search metadata returned in search results. Fun! This PR rectifies the per-file metadata, which should give us better results in manifests.