### PR TITLE
Added a stub for finalizing transfers

### DIFF
--- a/databases/databases.go
+++ b/databases/databases.go
@@ -51,6 +51,9 @@ type Database interface {
 	StageFiles(orcid string, fileIds []string) (uuid.UUID, error)
 	// returns the status of a given staging operation
 	StagingStatus(id uuid.UUID) (StagingStatus, error)
+	// performs any work needed to finalize a transfer with the given UUID,
+	// associated with the user with the given ORCID
+	Finalize(orcid string, id uuid.UUID) error
 	// returns the local username associated with the given ORCID
 	LocalUser(orcid string) (string, error)
 	// returns the saved state of the Database, loadable via Load

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -401,6 +401,10 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 	}
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db *Database) LocalUser(orcid string) (string, error) {
 	// no current mechanism for this
 	return "localuser", nil

--- a/databases/kbase/database.go
+++ b/databases/kbase/database.go
@@ -68,6 +68,10 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 	return databases.StagingStatusUnknown, err
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db *Database) LocalUser(orcid string) (string, error) {
 	return usernameForOrcid(orcid)
 }

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -226,6 +226,10 @@ func (db Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error) 
 	return databases.StagingStatusSucceeded, nil
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db Database) LocalUser(orcid string) (string, error) {
 	// no current mechanism for this
 	return "localuser", nil

--- a/dtstest/dtstest.go
+++ b/dtstest/dtstest.go
@@ -269,6 +269,10 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 	return databases.StagingStatusUnknown, nil
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db *Database) Endpoint() (endpoints.Endpoint, error) {
 	return db.Endpt, nil
 }


### PR DESCRIPTION
This PR adds the ability for DTS to signal to a database that a transfer has finished. We will use this to send a signal to the KBase staging service when a transfer manifest has been written, to initiate the movement of files from the DTS "holding pen" to the appropriate staging service folders. Right now, the signaling function is empty, waiting on a last PR from the staging service to expose an appropriate endpoint.