### PR TITLE
Added a stub for finalizing transfers, plus JDP metadata cleanup

### DIFF
--- a/databases/databases.go
+++ b/databases/databases.go
@@ -51,6 +51,9 @@ type Database interface {
 	StageFiles(orcid string, fileIds []string) (uuid.UUID, error)
 	// returns the status of a given staging operation
 	StagingStatus(id uuid.UUID) (StagingStatus, error)
+	// performs any work needed to finalize a transfer with the given UUID,
+	// associated with the user with the given ORCID
+	Finalize(orcid string, id uuid.UUID) error
 	// returns the local username associated with the given ORCID
 	LocalUser(orcid string) (string, error)
 	// returns the saved state of the Database, loadable via Load

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -197,9 +197,9 @@ func (db *Database) Resources(orcid string, fileIds []string) ([]frictionless.Da
 						GoldData struct {
 							GoldStampId string `json:"gold_stamp_id"`
 						} `json:"gold_data"`
-						ProposalId      int    `json:"proposal_id"`
-						ContentType     string `json:"content_type"`
-						PmoProjectId    int    `json:"pmo_project_id"`
+						ProposalId  int    `json:"proposal_id"`
+						ContentType string `json:"content_type"`
+						//PmoProjectId    int    `json:"pmo_project_id"`
 						AnalysisProject struct {
 							Status string `json:"status"`
 						} `json:"analysis_project"`
@@ -790,7 +790,12 @@ func (db *Database) filesFromSearch(params url.Values) (databases.SearchResults,
 					case "project_id":
 						extras += fmt.Sprintf(`"project_id": "%s"`, org.Id)
 					case "img_taxon_oid":
-						extras += fmt.Sprintf(`"img_taxon_oid": %d`, file.Metadata.IMG.TaxonOID)
+						var taxonOID int
+						err := json.Unmarshal(file.Metadata.IMG.TaxonOID, &taxonOID)
+						if err != nil {
+							return results, err
+						}
+						extras += fmt.Sprintf(`"img_taxon_oid": %d`, taxonOID)
 					}
 				}
 				extras += "}"

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -158,57 +158,20 @@ func (db *Database) Resources(orcid string, fileIds []string) ([]frictionless.Da
 		return nil, err
 	}
 
-	// NOTE: The metadata returned by this endpoint is different from what's
-	// NOTE: in search results, so we construct a DataResource gingerly here.
-	// NOTE: Someday things may make more sense...
 	type MetadataResponse struct {
 		Hits struct {
 			Hits []struct {
 				Type   string `json:"_type"`
 				Id     string `json:"_id"`
 				Source struct {
-					Date         string `json:"file_date"`
-					AddedDate    string `json:"added_date"`
-					ModifiedDate string `json:"modified_date"`
-					FilePath     string `json:"file_path"`
-					FileName     string `json:"file_name"`
-					FileSize     int    `json:"file_size"`
-					MD5Sum       string `json:"md5sum"`
-					Metadata     struct {
-						Img struct {
-							TaxonOid          int     `json:"taxon_oid"`
-							Database          string  `json:"database"`
-							AddDate           string  `json:"add_date"`
-							FileType          string  `json:"file_type"`
-							Domain            string  `json:"domain"`
-							TaxonDisplayName  string  `json:"taxon_display_name"`
-							NScaffolds        int     `json:"n_scaffolds"`
-							JgiProjectId      int     `json:"jgi_project_id"`
-							GcPercent         float64 `json:"gc_percent"`
-							TotalBases        int     `json:"total_bases"`
-							Assembled         string  `json:"assembled"`
-							AnalysisProjectId string  `json:"analysis_project_id"`
-						} `json:"img"`
-						PmoProject struct {
-							ScientificProgram string `json:"scientific_program"`
-							PiName            string `json:"pi_name"`
-							Name              string `json:"name"`
-						} `json:"pmo_project"`
-						GoldData struct {
-							GoldStampId string `json:"gold_stamp_id"`
-						} `json:"gold_data"`
-						ProposalId  int    `json:"proposal_id"`
-						ContentType string `json:"content_type"`
-						//PmoProjectId    int    `json:"pmo_project_id"`
-						AnalysisProject struct {
-							Status string `json:"status"`
-						} `json:"analysis_project"`
-						Portal struct {
-							DisplayLocation []string `json:"display_location"`
-							JdpKingdom      string   `json:"jdp_kingdom"`
-						} `json:"portal"`
-						// AnalysisProjectId string `json:"analysis_project_id"` <-- too polymorphic!
-					} `json:"metadata"`
+					Date         string   `json:"file_date"`
+					AddedDate    string   `json:"added_date"`
+					ModifiedDate string   `json:"modified_date"`
+					FilePath     string   `json:"file_path"`
+					FileName     string   `json:"file_name"`
+					FileSize     int      `json:"file_size"`
+					MD5Sum       string   `json:"md5sum"`
+					Metadata     Metadata `json:"metadata"`
 				} `json:"_source"`
 			} `json:"hits"`
 		} `json:"hits"`
@@ -247,7 +210,7 @@ func (db *Database) Resources(orcid string, fileIds []string) ([]frictionless.Da
 				ResourceType: "dataset",
 				Titles: []credit.Title{
 					{
-						Title: dataResourceName(md.Source.FileName),
+						Title: md.Source.Metadata.FinalDeliveryProject.Name,
 					},
 				},
 				Dates: []credit.EventDate{
@@ -643,7 +606,7 @@ func dataResourceFromFile(file File) frictionless.DataResource {
 			ResourceType: "dataset",
 			Titles: []credit.Title{
 				{
-					Title: filePath,
+					Title: file.Metadata.FinalDeliveryProject.Name,
 				},
 			},
 			Dates: []credit.EventDate{

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -401,6 +401,10 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 	}
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db *Database) LocalUser(orcid string) (string, error) {
 	// no current mechanism for this
 	return "localuser", nil

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -581,7 +581,7 @@ func dataResourceName(filename string) string {
 }
 
 // creates a DataResource from a File
-func dataResourceFromFile(file File) frictionless.DataResource {
+func dataResourceFromOrganismAndFile(organism Organism, file File) frictionless.DataResource {
 	id := "JDP:" + file.Id
 	format := formatFromFileName(file.Name)
 	fileTypes := fileTypesFromFile(file)
@@ -606,7 +606,7 @@ func dataResourceFromFile(file File) frictionless.DataResource {
 			ResourceType: "dataset",
 			Titles: []credit.Title{
 				{
-					Title: file.Metadata.FinalDeliveryProject.Name,
+					Title: organism.Title,
 				},
 			},
 			Dates: []credit.EventDate{
@@ -726,10 +726,7 @@ func (db *Database) filesFromSearch(params url.Values) (databases.SearchResults,
 		return results, err
 	}
 	type JDPResults struct {
-		Organisms []struct {
-			Id    string `json:"id"`
-			Files []File `json:"files"`
-		} `json:"organisms"`
+		Organisms []Organism `json:"organisms"`
 	}
 	results.Resources = make([]frictionless.DataResource, 0)
 	var jdpResults JDPResults
@@ -740,7 +737,7 @@ func (db *Database) filesFromSearch(params url.Values) (databases.SearchResults,
 	for _, org := range jdpResults.Organisms {
 		resources := make([]frictionless.DataResource, 0)
 		for _, file := range org.Files {
-			res := dataResourceFromFile(file)
+			res := dataResourceFromOrganismAndFile(org, file)
 
 			// add any requested additional metadata
 			if extraFields != nil {

--- a/databases/jdp/file.go
+++ b/databases/jdp/file.go
@@ -99,7 +99,8 @@ type Metadata struct {
 		DisplayName string `json:"display_name"`
 	} `json:"gold_data"`
 	IMG struct {
-		TaxonOID int `json:"taxon_oid"`
+		// TaxonOID can be either a number or a string, because who cares, apparently
+		TaxonOID json.RawMessage `json:"taxon_oid"`
 	} `json:"img,omitempty"`
 	// sequencing project metadata
 	SequencingProject struct {

--- a/databases/jdp/file.go
+++ b/databases/jdp/file.go
@@ -65,7 +65,56 @@ type File struct {
 
 // this type represents metadata associated with a File ^^^
 type Metadata struct {
-	// proposal info
+	AnalysisProject struct {
+		Status string `json:"status"`
+	} `json:"analysis_project"`
+	// analysis project ID, sometimes used as ITS project ID. This type can be a
+	// list or a number, so we have to unmarshal it into a RawMessage
+	AnalysisProjectId    json.RawMessage `json:"analysis_project_id"`
+	ContentType          string          `json:"content_type"`
+	FinalDeliveryProject struct {
+		Name                  string `json:"final_deliv_product_name"`
+		ProductSearchCategory string `json:"product_search_category"`
+	} `json:"final_deliv_project"`
+	GoldData struct {
+		// stamp ID
+		StampId string `json:"gold_stamp_id"`
+		// project URL
+		ProjectURL string `json:"gold_project_url"`
+		// display name
+		DisplayName string `json:"display_name"`
+	} `json:"gold_data"`
+	IMG struct {
+		// TaxonOID can be either a number or a string, because who cares, apparently
+		TaxonOID          json.RawMessage `json:"taxon_oid"`
+		Database          string          `json:"database"`
+		AddDate           string          `json:"add_date"`
+		FileType          string          `json:"file_type"`
+		Domain            string          `json:"domain"`
+		TaxonDisplayName  string          `json:"taxon_display_name"`
+		NScaffolds        int             `json:"n_scaffolds"`
+		JgiProjectId      int             `json:"jgi_project_id"`
+		GcPercent         float64         `json:"gc_percent"`
+		TotalBases        int             `json:"total_bases"`
+		Assembled         string          `json:"assembled"`
+		AnalysisProjectId string          `json:"analysis_project_id"`
+	} `json:"img,omitempty"`
+	NCBITaxon struct {
+		Order   string `json:"ncbi_taxon_order"`
+		Family  string `json:"ncbi_taxon_family"`
+		Genus   string `json:"ncbi_taxon_genus"`
+		Species string `json:"ncbi_taxon_species"`
+	} `json:"ncbi_taxon"`
+	NCBITaxonId int `json:"ncbi_taxon_id"`
+	Portal      struct {
+		DisplayLocation []string `json:"display_location"`
+		JdpKingdom      string   `json:"jdp_kingdom"`
+	} `json:"portal"`
+	PmoProject struct {
+		ScientificProgram string `json:"scientific_program"`
+		PiName            string `json:"pi_name"`
+		Name              string `json:"name"`
+	} `json:"pmo_project"`
 	Proposal struct {
 		// DOI of the awarded proposal
 		AwardDOI string `json:"award_doi"`
@@ -89,19 +138,7 @@ type Metadata struct {
 		// proposal DOI
 		DOI string `json:"doi"`
 	} `json:"proposal"`
-	// GOLD-related metadata
-	GoldData struct {
-		// stamp ID
-		StampId string `json:"gold_stamp_id"`
-		// project URL
-		ProjectURL string `json:"gold_project_url"`
-		// display name
-		DisplayName string `json:"display_name"`
-	} `json:"gold_data"`
-	IMG struct {
-		// TaxonOID can be either a number or a string, because who cares, apparently
-		TaxonOID json.RawMessage `json:"taxon_oid"`
-	} `json:"img,omitempty"`
+	ProposalId int `json:"proposal_id"`
 	// sequencing project metadata
 	SequencingProject struct {
 		// name of scientific program to which project belongs
@@ -110,24 +147,4 @@ type Metadata struct {
 	// sequencing project ID, sometimes used as ITS project ID. This type can be a
 	// list or a number, so we have to unmarshal it into a RawMessage
 	SequencingProjectId json.RawMessage `json:"sequencing_project_id"`
-	// NCBI taxon metadata
-	NCBITaxon struct {
-		Order   string `json:"ncbi_taxon_order"`
-		Family  string `json:"ncbi_taxon_family"`
-		Genus   string `json:"ncbi_taxon_genus"`
-		Species string `json:"ncbi_taxon_species"`
-	} `json:"ncbi_taxon"`
-	// NCBI taxon identifier
-	NCBITaxonId int `json:"ncbi_taxon_id"`
-	// portal metadata
-	Portal struct {
-		DisplayLocation []string `json:"display_location"`
-	} `json:"portal"`
-	// final project delivery metadata
-	FinalDeliveryProject struct {
-		ProductSearchCategory string `json:"product_search_category"`
-	} `json:"final_deliv_project"`
-	// analysis project ID, sometimes used as ITS project ID. This type can be a
-	// list or a number, so we have to unmarshal it into a RawMessage
-	AnalysisProjectId json.RawMessage `json:"analysis_project_id"`
 }

--- a/databases/jdp/file.go
+++ b/databases/jdp/file.go
@@ -25,6 +25,15 @@ import (
 	"encoding/json"
 )
 
+// This type represents metadata about an organism associated with one or
+// more files.
+type Organism struct {
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Title string `json:"title"`
+	Files []File `json:"files"`
+}
+
 // This type represents a single file entry in a JDP ElasticSearch result.
 type File struct {
 	// unique ID used by the DTS to manipulate the file

--- a/databases/kbase/database.go
+++ b/databases/kbase/database.go
@@ -68,6 +68,10 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 	return databases.StagingStatusUnknown, err
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db *Database) LocalUser(orcid string) (string, error) {
 	return usernameForOrcid(orcid)
 }

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -226,6 +226,10 @@ func (db Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error) 
 	return databases.StagingStatusSucceeded, nil
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db Database) LocalUser(orcid string) (string, error) {
 	// no current mechanism for this
 	return "localuser", nil

--- a/dtstest/dtstest.go
+++ b/dtstest/dtstest.go
@@ -269,6 +269,10 @@ func (db *Database) StagingStatus(id uuid.UUID) (databases.StagingStatus, error)
 	return databases.StagingStatusUnknown, nil
 }
 
+func (db *Database) Finalize(orcid string, id uuid.UUID) error {
+	return nil
+}
+
 func (db *Database) Endpoint() (endpoints.Endpoint, error) {
 	return db.Endpt, nil
 }

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -142,7 +142,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 3
-var patchVersion = 2
+var patchVersion = 3
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -142,7 +142,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 3
-var patchVersion = 1
+var patchVersion = 2
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -142,7 +142,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 3
-var patchVersion = 0
+var patchVersion = 1
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)


### PR DESCRIPTION
This was the original branch in which the transfer finalization logic appeared. It also includes a cleanup of JDP metadata types. I'm seeing whether this PR passes tests in GitHub's CI environment, which seems not to be working properly for #106 .