### PR TITLE
Adding a configuration name so e.g. dev/prod instances can share certain resources.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,8 @@ import (
 
 // a type with service configuration parameters
 type serviceConfig struct {
+	// Optional name for service configuration (e.g. "dev", "prod")
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// secret for decrypting access key authorization file
 	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
 	// port on which the service listens

--- a/dts.yaml.example
+++ b/dts.yaml.example
@@ -3,6 +3,7 @@
 
 # service parameters
 service:
+  name: dev                  # descriptive name for config (e.g. dev, prod)
   port: 8080                 # port on which the service listenѕ
   max_connections: 100       # maximum number of incoming HTTP connections
   max_payload_size: 100      # limit (if any) on DTS payload size (gigabytes)

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -325,7 +325,13 @@ type channelsType struct {
 // the main thread
 func processTasks() {
 	// create or recreate a persistent table of transfer-related tasks
-	dataStore := filepath.Join(config.Service.DataDirectory, "dts.gob")
+	var dataStore string
+	if config.Service.Name != "" {
+		dataStore = filepath.Join(config.Service.DataDirectory,
+			fmt.Sprintf("dts-%s.gob", config.Service.Name))
+	} else {
+		dataStore = filepath.Join(config.Service.DataDirectory, "dts.gob")
+	}
 	tasks := createOrLoadTasks(dataStore)
 
 	// parse the task channels into directional types as needed


### PR DESCRIPTION
This very simple change makes it possible to deploy `dev` and `prod` instances that share most resources but have different stores of jobs for processing. This prevents us from needing Acts of God when we want to spin up more than one instance.