### PR TITLE
Updated JDP metadata to include Organism-level stuff.

### DIFF
--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -434,8 +434,7 @@ func (db Database) post(resource string, body io.Reader) ([]byte, error) {
 	default:
 		defer resp.Body.Close()
 		data, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("An error occurred mapping NMDC data objects to studies: %s",
-			string(data))
+		return nil, fmt.Errorf("An error occurred: %s", string(data))
 	}
 }
 


### PR DESCRIPTION
It turns out that the (undocumented) per-file metadata endpoint the JDP team added for us is perfectly capable of delivering "top-level" (organism) metadata for each of its files if one sets a flag indicating that results should be "aggregated." I've taken the opportunity to merge the code paths for file search and per-file "descriptor" (metadata) retrieval.

This PR should go in after the Frictionless overhaul PR, which is waiting on my deployment of a "production" Spin instance of DTS (which is now at the top of my list!).