### PR TITLE
Updated NMDC metadata to include inlined biosample metadata descriptors.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -118,31 +118,31 @@ func readConfig(bytes []byte) error {
 
 func validateServiceParameters(params serviceConfig) error {
 	if params.Port < 0 || params.Port > 65535 {
-		return InvalidServiceConfigError{
+		return &InvalidServiceConfigError{
 			Message: fmt.Sprintf("Invalid port: %d (must be 0-65535)", params.Port),
 		}
 	}
 	if params.MaxConnections <= 0 {
-		return InvalidServiceConfigError{
+		return &InvalidServiceConfigError{
 			Message: fmt.Sprintf("Invalid max_connections: %d (must be positive)",
 				params.MaxConnections),
 		}
 	}
 	if params.Endpoint != "" {
 		if _, found := Endpoints[params.Endpoint]; !found {
-			return InvalidServiceConfigError{
+			return &InvalidServiceConfigError{
 				Message: fmt.Sprintf("Invalid endpoint: %s", params.Endpoint),
 			}
 		}
 	}
 	if params.PollInterval <= 0 {
-		return InvalidServiceConfigError{
+		return &InvalidServiceConfigError{
 			Message: fmt.Sprintf("Non-positive poll interval specified: (%d s)",
 				params.PollInterval),
 		}
 	}
 	if params.DeleteAfter <= 0 {
-		return InvalidServiceConfigError{
+		return &InvalidServiceConfigError{
 			Message: fmt.Sprintf("Non-positive task deletion period specified: (%d h)",
 				params.DeleteAfter),
 		}
@@ -153,13 +153,13 @@ func validateServiceParameters(params serviceConfig) error {
 func validateEndpoints(endpoints map[string]endpointConfig) error {
 	for name, endpoint := range endpoints {
 		if endpoint.Id.String() == "" { // invalid endpoint UUID
-			return InvalidEndpointConfigError{
+			return &InvalidEndpointConfigError{
 				Endpoint: name,
 				Message:  "Invalid UUID",
 			}
 		}
 		if endpoint.Provider == "" { // no provider given
-			return InvalidEndpointConfigError{
+			return &InvalidEndpointConfigError{
 				Endpoint: name,
 				Message:  "No provider specified",
 			}
@@ -171,19 +171,19 @@ func validateEndpoints(endpoints map[string]endpointConfig) error {
 func validateDatabases(databases map[string]databaseConfig) error {
 	for name, db := range databases {
 		if db.Endpoint == "" && len(db.Endpoints) == 0 {
-			return InvalidDatabaseConfigError{
+			return &InvalidDatabaseConfigError{
 				Database: name,
 				Message:  "No endpoints specified",
 			}
 		} else if db.Endpoint != "" && len(db.Endpoints) > 0 {
-			return InvalidDatabaseConfigError{
+			return &InvalidDatabaseConfigError{
 				Database: name,
 				Message:  "EITHER endpoint OR endpoints may be specified, but not both",
 			}
 		} else if db.Endpoint != "" {
 			// does the endpoint exist in our configuration?
 			if _, found := Endpoints[db.Endpoint]; !found {
-				return InvalidDatabaseConfigError{
+				return &InvalidDatabaseConfigError{
 					Database: name,
 					Message:  fmt.Sprintf("Invalid endpoint for database %s: %s", name, db.Endpoint),
 				}
@@ -192,7 +192,7 @@ func validateDatabases(databases map[string]databaseConfig) error {
 			// do all functional endpoints exist in our configuration?
 			for functionalName, endpointName := range db.Endpoints {
 				if _, found := Endpoints[endpointName]; !found {
-					return InvalidDatabaseConfigError{
+					return &InvalidDatabaseConfigError{
 						Database: name,
 						Message:  fmt.Sprintf("Invalid %s endpoint for database %s: %s", functionalName, name, endpointName),
 					}

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -141,6 +141,12 @@ func RegisterDatabase(dbName string, createDb func() (Database, error)) error {
 		firstTime = false
 	}
 
+	// make one to check the configuration
+	_, err := createDb()
+	if err != nil {
+		return err
+	}
+
 	if _, found := createDatabaseFuncs_[dbName]; found {
 		return &AlreadyRegisteredError{
 			Database: dbName,

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -44,8 +44,11 @@ type Database interface {
 	// search for files visible to the user with the given ORCID using the given
 	// parameters
 	Search(orcid string, params SearchParameters) (SearchResults, error)
-	// returns a slice of Frictionless descriptors for the resources visible to
-	// the user with the given ORCID that match the given IDs
+	// Returns a slice of Frictionless descriptors for the resources visible to
+	// the user with the given ORCID that match the given IDs. A descriptor can
+	// refer to a file or inline data, depending respectively on the presence of
+	// a `path` or `data` field. Descriptors with inline data are not involved in
+	// file transfers and appear only in a transfer manifest.
 	Descriptors(orcid string, fileIds []string) ([]map[string]interface{}, error)
 	// begins staging the files visible to the user with the given ORCID for
 	// transfer, returning a UUID representing the staging operation

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -44,11 +44,15 @@ type Database interface {
 	// search for files visible to the user with the given ORCID using the given
 	// parameters
 	Search(orcid string, params SearchParameters) (SearchResults, error)
-	// Returns a slice of Frictionless descriptors for the resources visible to
-	// the user with the given ORCID that match the given IDs. A descriptor can
+	// Returns a slice of Frictionless descriptors associated with files with the
+	// given IDs that are visible to the user with the given ORCID. A descriptor can
 	// refer to a file or inline data, depending respectively on the presence of
-	// a `path` or `data` field. Descriptors with inline data are not involved in
-	// file transfers and appear only in a transfer manifest.
+	// a `path` or `data` field. Data descriptors (descriptors with inline data)
+	// do not have corresponding file IDs and usually hold metadata related to one
+	// or more of the requested files--they are not involved in file transfers and
+	// appear only in a transfer manifest. If any data descriptors are returned
+	// by this call, the number of descriptors returned will exceed the number of
+	// requested file IDs by the number of data descriptors.
 	Descriptors(orcid string, fileIds []string) ([]map[string]interface{}, error)
 	// begins staging the files visible to the user with the given ORCID for
 	// transfer, returning a UUID representing the staging operation

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -142,7 +142,7 @@ func RegisterDatabase(dbName string, createDb func() (Database, error)) error {
 	}
 
 	if _, found := createDatabaseFuncs_[dbName]; found {
-		return AlreadyRegisteredError{
+		return &AlreadyRegisteredError{
 			Database: dbName,
 		}
 	} else {
@@ -163,7 +163,7 @@ func NewDatabase(dbName string) (Database, error) {
 		if createDb, valid := createDatabaseFuncs_[dbName]; valid {
 			db, err = createDb()
 		} else {
-			err = NotFoundError{dbName}
+			err = &NotFoundError{dbName}
 		}
 		if err == nil {
 			allDatabases_[dbName] = db // stash it

--- a/databases/http.go
+++ b/databases/http.go
@@ -36,7 +36,7 @@ func SecureHttpClient() http.Client {
 		Timeout: time.Second * 10,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Scheme == "http" {
-				return DowngradedRedirectError{
+				return &DowngradedRedirectError{
 					Endpoint: fmt.Sprintf("%s%s", req.URL.Host, req.URL.Path),
 				}
 			}

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -73,7 +73,7 @@ func NewDatabase() (databases.Database, error) {
 
 	// make sure we are using only a single endpoint
 	if config.Databases["jdp"].Endpoint == "" {
-		return nil, databases.InvalidEndpointsError{
+		return nil, &databases.InvalidEndpointsError{
 			Database: "jdp",
 			Message:  "The JGI data portal should only have a single endpoint configured.",
 		}

--- a/databases/kbase/errors.go
+++ b/databases/kbase/errors.go
@@ -26,10 +26,10 @@ import (
 )
 
 // This error type is returned when a KBase user/ORCID spreadsheet file is invalid.
-type InvalidKBaseUserSpreadsheet struct {
+type InvalidKBaseUserSpreadsheetError struct {
 	File, Message string
 }
 
-func (e InvalidKBaseUserSpreadsheet) Error() string {
+func (e InvalidKBaseUserSpreadsheetError) Error() string {
 	return fmt.Sprintf("KBase user spreadsheet file %s is invalid: %s", e.File, e.Message)
 }

--- a/databases/kbase/user_federation.go
+++ b/databases/kbase/user_federation.go
@@ -168,7 +168,7 @@ func readUserTable() (map[string]string, error) {
 	slog.Info(fmt.Sprintf("Reading KBase user table from %s", filename))
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, InvalidKBaseUserSpreadsheet{
+		return nil, &InvalidKBaseUserSpreadsheetError{
 			File:    kbaseUserTableFile,
 			Message: "nonexistent file",
 		}
@@ -194,14 +194,14 @@ func readUserTable() (map[string]string, error) {
 	reader := csv.NewReader(file)
 	records, err := reader.ReadAll()
 	if err != nil {
-		return nil, InvalidKBaseUserSpreadsheet{
+		return nil, &InvalidKBaseUserSpreadsheetError{
 			File:    kbaseUserTableFile,
 			Message: "Couldn't parse CVS file",
 		}
 	}
 	for _, record := range records {
 		if len(record) != 2 {
-			return nil, InvalidKBaseUserSpreadsheet{
+			return nil, &InvalidKBaseUserSpreadsheetError{
 				File:    kbaseUserTableFile,
 				Message: fmt.Sprintf("%d comma-separated columns found (2 expected)", len(record)),
 			}
@@ -217,7 +217,7 @@ func readUserTable() (map[string]string, error) {
 		} else if !isOrcid(record[orcidColumn]) {
 			// we've already established the ORCID column, but this line disagrees,
 			// so the whole file is suspect
-			return nil, InvalidKBaseUserSpreadsheet{
+			return nil, &InvalidKBaseUserSpreadsheetError{
 				File:    kbaseUserTableFile,
 				Message: "Different lines list username, ORCID data in different columns",
 			}
@@ -235,7 +235,7 @@ func readUserTable() (map[string]string, error) {
 			// is consistent
 			if existingUser, found := usersForOrcids[orcid]; found {
 				if existingUser != orcid {
-					return nil, InvalidKBaseUserSpreadsheet{
+					return nil, &InvalidKBaseUserSpreadsheetError{
 						File:    kbaseUserTableFile,
 						Message: fmt.Sprintf("ORCID %s is associated with multiple users", orcid),
 					}
@@ -245,7 +245,7 @@ func readUserTable() (map[string]string, error) {
 			}
 			if existingOrcid, found := orcidsForUsers[username]; found {
 				if existingOrcid != orcid {
-					return nil, InvalidKBaseUserSpreadsheet{
+					return nil, &InvalidKBaseUserSpreadsheetError{
 						File:    kbaseUserTableFile,
 						Message: fmt.Sprintf("User %s has multiple ORCIDs", username),
 					}
@@ -257,7 +257,7 @@ func readUserTable() (map[string]string, error) {
 	}
 
 	if len(usersForOrcids) == 0 {
-		return nil, InvalidKBaseUserSpreadsheet{
+		return nil, &InvalidKBaseUserSpreadsheetError{
 			File:    kbaseUserTableFile,
 			Message: "No valid username/ORCID pairs found",
 		}

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -59,21 +59,21 @@ type Database struct {
 func NewDatabase() (databases.Database, error) {
 	nmdcUser, haveNmdcUser := os.LookupEnv("DTS_NMDC_USER")
 	if !haveNmdcUser {
-		return nil, databases.UnauthorizedError{
+		return nil, &databases.UnauthorizedError{
 			Database: "nmdc",
 			Message:  "No NMDC user (DTS_NMDC_USER) was provided for authentication",
 		}
 	}
 	nmdcPassword, haveNmdcPassword := os.LookupEnv("DTS_NMDC_PASSWORD")
 	if !haveNmdcPassword {
-		return nil, databases.UnauthorizedError{
+		return nil, &databases.UnauthorizedError{
 			Database: "nmdc",
 			Message:  "No NMDC password (DTS_NMDC_PASSWORD) was provided for authentication",
 		}
 	}
 
 	if config.Databases["nmdc"].Endpoint != "" {
-		return nil, databases.InvalidEndpointsError{
+		return nil, &databases.InvalidEndpointsError{
 			Database: "nmdc",
 			Message:  "NMDC requires 'nersc' and 'emsl' endpoints to be specified",
 		}
@@ -82,7 +82,7 @@ func NewDatabase() (databases.Database, error) {
 	for _, functionalName := range []string{"nersc", "emsl"} {
 		// was this functional name assigned to an endpoint?
 		if _, found := config.Databases["nmdc"].Endpoints[functionalName]; !found {
-			return nil, databases.InvalidEndpointsError{
+			return nil, &databases.InvalidEndpointsError{
 				Database: "nmdc",
 				Message:  fmt.Sprintf("Could not find '%s' endpoint for NMDC database", functionalName),
 			}

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -22,8 +22,8 @@
 package nmdc
 
 import (
-	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -154,12 +154,21 @@ func (db *Database) Search(orcid string, params databases.SearchParameters) (dat
 		p.Add("filter", params.Query)
 	}
 
+	var dataObjects []DataObject
+	var err error
 	if p.Has("study_id") { // fetch data objects associated with this study
-		return db.dataObjectsForStudy(p.Get("study_id"), p)
+		dataObjects, err = db.dataObjectsForStudy(p.Get("study_id"), p)
+	} else {
+		dataObjects, err = db.dataObjects(p)
+	}
+	if err != nil {
+		return databases.SearchResults{}, err
 	}
 
-	// otherwise, simply call the data_objects/ endpoint (possibly with a filter applied)
-	return db.dataObjects(p)
+	descriptors, _, err := db.createDataObjectAndBiosampleDescriptors(dataObjects)
+	return databases.SearchResults{
+		Descriptors: descriptors,
+	}, err
 }
 
 func (db Database) Descriptors(orcid string, fileIds []string) ([]map[string]interface{}, error) {
@@ -167,73 +176,26 @@ func (db Database) Descriptors(orcid string, fileIds []string) ([]map[string]int
 		return nil, err
 	}
 
-	// we use the /data_objects/{data_object_id} GET endpoint to retrieve metadata
-	// for individual files
-
-	// gather relevant study IDs, biosample and credit metadata
-	studyIdForDataObjectId, err := db.studyIdsForDataObjectIds(fileIds)
-	if err != nil {
-		return nil, err
-	}
-	biosampleMdForStudyId := make(map[string]json.RawMessage)
-	creditForStudyId := make(map[string]credit.CreditMetadata)
-	for _, studyId := range studyIdForDataObjectId {
-		biosampleMd, found := biosampleMdForStudyId[studyId]
-		if !found {
-			biosampleMd, err = db.biosampleMetadataForStudy(studyId)
-			if err != nil {
-				return nil, err
-			}
-			print("Voo-ba!\n")
-			biosampleMdForStudyId[studyId] = biosampleMd
-		}
-
-		credit, found := creditForStudyId[studyId]
-		if !found {
-			credit, err = db.creditMetadataForStudy(studyId)
-			if err != nil {
-				return nil, err
-			}
-			creditForStudyId[studyId] = credit // cache for other data objects
-		}
-		creditForStudyId[studyId] = credit
-	}
-
-	// construct data resources from the IDs
-	descriptors := make([]map[string]interface{}, len(fileIds))
+	// construct data resource descriptors from the IDs and make lists of
+	// workflow executions and data generations (for metadata)
+	dataObjects := make([]DataObject, len(fileIds))
 	for i, fileId := range fileIds {
 		body, err := db.get(fmt.Sprintf("data_objects/%s", fileId), url.Values{})
 		if err != nil {
 			return nil, err
 		}
-		var dataObject DataObject
-		err = json.Unmarshal(body, &dataObject)
+		err = json.Unmarshal(body, &dataObjects[i])
 		if err != nil {
 			return nil, err
 		}
-		descriptor := db.descriptorFromDataObject(dataObject)
-
-		// add credit metadata
-		resourceId := descriptor["id"].(string)
-		studyId := studyIdForDataObjectId[resourceId]
-		credit := creditForStudyId[studyId]
-		credit.ResourceType = "dataset"
-		credit.Identifier = resourceId
-		descriptor["credit"] = credit
-		descriptors[i] = descriptor
 	}
 
-	// include any relevant biosample metadata (inline data) descriptors
-	for studyId, biosampleMd := range biosampleMdForStudyId {
-		descriptor := map[string]interface{}{
-			"name":  fmt.Sprintf("biosample-metadata-for-study-%s", studyId),
-			"title": fmt.Sprintf("NMDC biosample metadata for study %s", studyId),
-			"data":  biosampleMd,
-		}
-		descriptors = append(descriptors, descriptor)
+	// fetch metadata for data objects and biosamples and turn them into descriptors
+	dataObjectDescriptors, biosampleDescriptors, err := db.createDataObjectAndBiosampleDescriptors(dataObjects)
+	if err != nil {
+		return nil, err
 	}
-
-	return descriptors, nil
+	return slices.Concat(dataObjectDescriptors, biosampleDescriptors), nil
 }
 
 func (db Database) StageFiles(orcid string, fileIds []string) (uuid.UUID, error) {
@@ -271,9 +233,9 @@ func (db *Database) Load(state databases.DatabaseSaveState) error {
 	return nil
 }
 
-//--------------------
+//====================
 // Internal machinery
-//--------------------
+//====================
 
 const (
 	// NOTE: for now, we use the dev environment (-dev), not prod (which has bugs!)
@@ -281,11 +243,13 @@ const (
 	// NOTE: which are synced daily-esque. They will sort this out in the coming year,
 	// NOTE: and it looks like PostGres is probably going to prevail.
 	// NOTE: (See https://github.com/microbiomedata/NMDC_documentation/blob/main/docs/howto_guides/portal_guide.md)
-	baseApiURL  = "https://api-dev.microbiomedata.org/"       // mongoDB
+	baseApiURL  = "https://api.microbiomedata.org/"           // mongoDB
 	baseDataURL = "https://data-dev.microbiomedata.org/data/" // postgres (use in future)
 )
 
-// Authorization / authentication
+//------------------------------
+// Access to NMDC API endpoints
+//------------------------------
 
 type authorization struct {
 	// API user credential
@@ -461,39 +425,168 @@ func (db Database) post(resource string, body io.Reader) ([]byte, error) {
 	}
 }
 
+//----------------
+// Metadata types
+//----------------
+
 // data object type for JSON marshalling
 // (see https://microbiomedata.github.io/nmdc-schema/DataObject/)
 type DataObject struct {
-	FileSizeBytes          int            `json:"file_size_bytes"`
-	MD5Checksum            string         `json:"md5_checksum"`
-	DataObjectType         string         `json:"data_object_type"`
-	CompressionType        string         `json:"compression_type"`
-	URL                    string         `json:"url"`
-	Type                   string         `json:"type"`
-	Id                     string         `json:"id"`
-	Name                   string         `json:"name"`
-	Description            string         `json:"description"`
-	WasGeneratedBy         DataGeneration `json:"was_informed_by"`
-	AlternativeIdentifiers []string       `json:"alternative_identifiers,omitempty"`
+	FileSizeBytes          int      `json:"file_size_bytes"`
+	MD5Checksum            string   `json:"md5_checksum"`
+	DataObjectType         string   `json:"data_object_type"`
+	CompressionType        string   `json:"compression_type"`
+	URL                    string   `json:"url"`
+	Type                   string   `json:"type"`
+	Id                     string   `json:"id"`
+	Name                   string   `json:"name"`
+	Description            string   `json:"description"`
+	WasGeneratedBy         string   `json:"was_generated_by"`
+	AlternativeIdentifiers []string `json:"alternative_identifiers,omitempty"`
 }
 
-type DataGeneration struct {
-	AssociatedStudies []string
+// https://microbiomedata.github.io/nmdc-schema/CreditAssociation/
+type CreditAssociation struct {
+	Roles  []string    `json:"applied_roles"`
+	Person PersonValue `json:"applies_to_person"`
+	Type   string      `json:"type,omitempty"`
 }
 
-func (db Database) descriptorFromDataObject(dataObject DataObject) map[string]interface{} {
+// https://microbiomedata.github.io/nmdc-schema/Doi/
+type Doi struct {
+	Value    string `json:"doi_value"`
+	Provider string `json:"doi_provider,omitempty"`
+	Category string `json:"doi_category"`
+}
+
+// https://microbiomedata.github.io/nmdc-schema/PersonValue/
+type PersonValue struct {
+	Email    string   `json:"email,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Orcid    string   `json:"orcid,omitempty"`
+	Websites []string `json:"websites,omitempty"`
+	RawValue string   `json:"has_raw_value,omitempty"` // name in 'FIRST LAST' format (if present)
+}
+
+// https://microbiomedata.github.io/nmdc-schema/Study/
+type Study struct { // partial representation, includes only relevant fields
+	Id                 string              `json:"id"`
+	AlternativeNames   []string            `json:"alternative_names,omitempty"`
+	AlternativeTitles  []string            `json:"alternative_titles,omitempty"`
+	AssociatedDois     []Doi               `json:"associated_dois,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	FundingSources     []string            `json:"funding_sources,omitempty"`
+	CreditAssociations []CreditAssociation `json:"has_credit_associations,omitempty"`
+	Name               string              `json:"name,omitempty"`
+	RelatedIdentifiers string              `json:"related_identifiers,omitempty"`
+	Title              string              `json:"title,omitempty"`
+}
+
+// https://microbiomedata.github.io/nmdc-schema/WorkflowExecution/
+type WorkflowExecution struct {
+	Id         string        `json:"id"`
+	Name       string        `json:"name"`
+	Studies    []Study       `json:"studies"`
+	Biosamples []interface{} `json:"biosamples"`
+}
+
+// fetches file metadata for data objects associated with the given study
+func (db Database) dataObjectsForStudy(studyId string, params url.Values) ([]DataObject, error) {
+	body, err := db.get(fmt.Sprintf("data_objects/study/%s", studyId), params)
+	if err != nil {
+		return nil, err
+	}
+
+	type DataObjectsByStudyResults struct {
+		BiosampleId string       `json:"biosample_id"`
+		DataObjects []DataObject `json:"data_objects"`
+	}
+	var objectSets []DataObjectsByStudyResults
+	err = json.Unmarshal(body, &objectSets)
+	if err != nil {
+		return nil, err
+	}
+
+	dataObjects := make([]DataObject, 0)
+	for _, objectSet := range objectSets {
+		for _, dataObject := range objectSet.DataObjects {
+			dataObjects = append(dataObjects, dataObject)
+		}
+	}
+	return dataObjects, nil
+}
+
+// fetches metadata for data objects based on the given URL search parameters
+func (db Database) dataObjects(params url.Values) ([]DataObject, error) {
+	// extract any requested "extra" metadata fields (and scrub them from params)
+	// FIXME: no extra fields yet, so we simply remove this parameter
+	//var extraFields []string
+	if params.Has("extra") {
+		//extraFields = strings.Split(params.Get("extra"), ",")
+		params.Del("extra")
+	}
+
+	body, err := db.get("data_objects/", params)
+	type DataObjectResults struct {
+		// NOTE: we only extract the results field for now
+		Results []DataObject `json:"results"`
+	}
+	if err != nil {
+		return nil, err
+	}
+	var dataObjectResults DataObjectResults
+	err = json.Unmarshal(body, &dataObjectResults)
+	return dataObjectResults.Results, err
+}
+
+// returns descriptors for data objects and related biosample metadata
+func (db Database) createDataObjectAndBiosampleDescriptors(dataObjects []DataObject) ([]map[string]interface{}, []map[string]interface{}, error) {
+	// create data object descriptors and fill in metadata
+	dataObjectDescriptors := make([]map[string]interface{}, len(dataObjects))
+	creditForWorkflow := make(map[string]credit.CreditMetadata)
+	biosampleForWorkflow := make(map[string]interface{})
+	for i, dataObject := range dataObjects {
+		workflowId := dataObject.WasGeneratedBy
+		if _, found := creditForWorkflow[workflowId]; !found {
+			var err error
+			creditForWorkflow[workflowId], biosampleForWorkflow[workflowId], err = db.creditAndBiosampleForWorkflow(workflowId)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		dataObjectDescriptors[i] = db.createDataObjectDescriptor(dataObject, creditForWorkflow[workflowId])
+	}
+
+	// create biosample descriptors
+	biosampleDescriptors := make([]map[string]interface{}, len(biosampleForWorkflow))
+	for _, biosample := range biosampleForWorkflow {
+		studyId := biosample.(map[string]interface{})["associated_studies"].(string)
+		descriptor := map[string]interface{}{
+			"name":  fmt.Sprintf("biosample-metadata-for-study-%s", studyId),
+			"title": fmt.Sprintf("NMDC biosample metadata for study %s", studyId),
+			"data":  biosample,
+		}
+		biosampleDescriptors = append(biosampleDescriptors, descriptor)
+	}
+
+	return dataObjectDescriptors, biosampleDescriptors, nil
+}
+
+// returns a descriptor for the given data object, including the given credit
+// metadata (mined from the study to which the data object belongs)
+func (db Database) createDataObjectDescriptor(dataObject DataObject, studyCredit credit.CreditMetadata) map[string]interface{} {
+	// fill in some particulars
+	objectCredit := studyCredit
+	objectCredit.Descriptions = append(objectCredit.Descriptions,
+		credit.Description{
+			DescriptionText: dataObject.Description,
+			Language:        "en",
+		})
+	objectCredit.Identifier = dataObject.Id
+	objectCredit.Url = dataObject.URL
 	descriptor := map[string]interface{}{
-		"bytes": dataObject.FileSizeBytes,
-		"credit": credit.CreditMetadata{
-			Descriptions: []credit.Description{
-				{
-					DescriptionText: dataObject.Description,
-					Language:        "en",
-				},
-			},
-			Identifier: dataObject.Id,
-			Url:        dataObject.URL,
-		},
+		"bytes":       dataObject.FileSizeBytes,
+		"credit":      objectCredit,
 		"description": dataObject.Description,
 		"format":      formatFromType(dataObject.Type),
 		"hash":        dataObject.MD5Checksum,
@@ -516,240 +609,45 @@ func (db Database) descriptorFromDataObject(dataObject DataObject) map[string]in
 	return descriptor
 }
 
-func (db Database) studyIdsForDataObjectIds(dataObjectIds []string) (map[string]string, error) {
-	// We create an aggregation query on the data_generation_set collection.
-	// The data_generation_set collection associates studies with data objects:
-	// * the associated_studies field points to a study_set collection
-	// * the was_informed_by field points to a workflow_execution_set collection,
-	//   whose has_output field points to a data_object_set collection
-	//
-	// NOTE: The API documentation for find/aggregate queries
-	// NOTE: (https://api.microbiomedata.org/docs#/queries/run_query_queries_run_post)
-	// NOTE: includes words of caution:
-	// NOTE:
-	// NOTE: > For `find` and `aggregate`, note that cursor batching/pagination does
-	// NOTE: > not work via this API, so ensure that you construct a command that
-	// NOTE: > will return what you need in the "first batch". Also, the maximum
-	// NOTE: > size of the returned payload is 16MB.
-	// NOTE:
-	// NOTE: If we need to, we can break up our aggregate queries into smaller
-	// NOTE: chunks, since these queries are independent.
-	type MatchIdInSlice struct {
-		In []string `json:"$in,omitempty"`
-	}
-	type MatchOperation struct {
-		// matches an ID with one of those in the given list
-		Id MatchIdInSlice `json:"id"`
-	}
-	type LookupOperation struct {
-		From         string `json:"from"`
-		LocalField   string `json:"localField"`
-		ForeignField string `json:"foreignField"`
-		As           string `json:"as"`
-	}
-	type PipelineOperation struct {
-		// this is a bit cheesy but is simple and works
-		// we use struct pointers here so omitempty works properly
-		Match  *MatchOperation  `json:"$match,omitempty"`
-		Lookup *LookupOperation `json:"$lookup,omitempty"`
-	}
-	type CursorProperty struct {
-		BatchSize int `json:"batchsize,omitempty"`
-	}
-	type AggregateRequest struct {
-		Aggregate string              `json:"aggregate"`
-		Pipeline  []PipelineOperation `json:"pipeline"`
-		Cursor    CursorProperty      `json:"cursor,omitempty"`
-	}
-	data, err := json.Marshal(AggregateRequest{
-		Aggregate: "data_object_set",
-		Pipeline: []PipelineOperation{
-			// match against our set of data object IDs
-			{
-				Match: &MatchOperation{
-					Id: MatchIdInSlice{
-						In: dataObjectIds,
-					},
-				},
-			},
-			// look up the data object's workflow execution set
-			// (the study IDs for the data generation set are in
-			//  the associated_studies field)
-			{
-				Lookup: &LookupOperation{
-					From:         "data_generation_set",
-					LocalField:   "was_generated_by",
-					ForeignField: "id",
-					As:           "data_generation_sets",
-				},
-			},
-		},
-	})
-	if err != nil {
-		return nil, err
+// fetch credit and biosample metadata related to the given workflow execution ID
+func (db *Database) creditAndBiosampleForWorkflow(workflowExecId string) (credit.CreditMetadata, map[string]interface{}, error) {
+	var relatedCredit credit.CreditMetadata
+	var relatedBiosample map[string]interface{} // pure-JSON representation
+
+	if workflowExecId == "" {
+		return relatedCredit, relatedBiosample, errors.New("No workflow execution ID provided!")
 	}
 
-	// run the query and extract the results
-	// NOTE: recall that trailing slashes in POSTs currently cause chaos!
-	body, err := db.post("queries:run", bytes.NewReader(data))
-	if err != nil {
-		return nil, err
-	}
-	type DataGenerationSet struct {
-		Id                string   `json:"id"`
-		AssociatedStudies []string `json:"associated_studies"`
-	}
-	type DataObjectAndDataGenerationSet struct {
-		DataObjectId       string              `json:"id"`
-		DataGenerationSets []DataGenerationSet `json:"data_generation_sets"`
-	}
-	type QueryResults struct {
-		Ok     int `json:"ok"`
-		Cursor struct {
-			FirstBatch []DataObjectAndDataGenerationSet `json:"firstBatch"`
-			Id         int                              `json:"id"`
-			NS         string                           `json:"ns"`
-		}
-	}
-	var results QueryResults
-	err = json.Unmarshal(body, &results)
-	if err != nil {
-		return nil, err
-	}
+	if strings.Contains(workflowExecId, "nmdc:wf") {
+		// data object is an analysis product; workflow execution has metadata
 
-	// map each data object ID to the corresponding study ID
-	studyIdForDataObjectId := make(map[string]string)
-	for _, record := range results.Cursor.FirstBatch {
-		// FIXME: for now, take the first study in the first data generation set
-		if len(record.DataGenerationSets) > 0 {
-			if len(record.DataGenerationSets[0].AssociatedStudies) > 0 {
-				studyIdForDataObjectId[record.DataObjectId] = record.DataGenerationSets[0].AssociatedStudies[0]
-			} else {
-				slog.Debug(fmt.Sprintf("No study is associated with the data object %s", record.DataObjectId))
-			}
-		} else {
-			slog.Debug(fmt.Sprintf("No data generation info was found for the data object %s", record.DataObjectId))
+		resource := fmt.Sprintf("workflow_executions/%s/related_resources", workflowExecId)
+		body, err := db.get(resource, url.Values{})
+		if err != nil {
+			return credit.CreditMetadata{}, nil, err
 		}
+		var workflowExec WorkflowExecution
+		err = json.Unmarshal(body, &workflowExec)
+
+		// credit metadata
+		if len(workflowExec.Studies) > 0 {
+			relatedCredit = db.creditMetadataForStudy(workflowExec.Studies[0])
+		}
+
+		// biosample metadata
+		if len(workflowExec.Biosamples) > 0 { // FIXME: can be > 1??
+			relatedBiosample = workflowExec.Biosamples[0].(map[string]interface{})
+		}
+
+		return relatedCredit, relatedBiosample, nil
+	} else if strings.Contains(workflowExecId, "nmdc:om") {
+		// data object is raw data; we don't fetch such metadata
 	}
-	return studyIdForDataObjectId, err
+	return relatedCredit, relatedBiosample, nil
 }
 
-// fetches metadata for data objects (no credit metadata, alas) based on the
-// given URL search parameters
-func (db Database) dataObjects(params url.Values) (databases.SearchResults, error) {
-	var results databases.SearchResults
-
-	// extract any requested "extra" metadata fields (and scrub them from params)
-	// FIXME: no extra fields yet, so we simply remove this parameter
-	//var extraFields []string
-	if params.Has("extra") {
-		//extraFields = strings.Split(params.Get("extra"), ",")
-		params.Del("extra")
-	}
-
-	body, err := db.get("data_objects/", params)
-	type DataObjectResults struct {
-		// NOTE: we only extract the results field for now
-		Results []DataObject `json:"results"`
-	}
-	if err != nil {
-		return results, err
-	}
-	var dataObjectResults DataObjectResults
-	err = json.Unmarshal(body, &dataObjectResults)
-	if err != nil {
-		return results, err
-	}
-
-	// map data object IDs to study IDs so we can retrieve credit info
-
-	// assemble all data object identifiers and map them to study IDs
-	dataObjectIds := make([]string, len(dataObjectResults.Results))
-	for i, dataObject := range dataObjectResults.Results {
-		dataObjectIds[i] = dataObject.Id
-	}
-	studyIdForDataObjectId, err := db.studyIdsForDataObjectIds(dataObjectIds)
-	if err != nil {
-		return results, err
-	}
-
-	// create data resources from data objects, fetch study metadata, and fill in
-	// data resource credit information
-	results.Descriptors = make([]map[string]interface{}, len(dataObjectResults.Results))
-	creditForStudyId := make(map[string]credit.CreditMetadata)
-	for i, dataObject := range dataObjectResults.Results {
-		studyId := studyIdForDataObjectId[dataObject.Id]
-		credit, foundStudyCredit := creditForStudyId[studyId]
-		if !foundStudyCredit {
-			credit, err = db.creditMetadataForStudy(studyId)
-			if err != nil {
-				return results, err
-			}
-			creditForStudyId[studyId] = credit // cache for other data objects
-		}
-		descriptor := db.descriptorFromDataObject(dataObject)
-		descriptor["credit"] = credit
-		results.Descriptors[i] = descriptor
-	}
-
-	return results, nil
-}
-
-// fetches credit metadata for the study with the given ID
-func (db Database) creditMetadataForStudy(studyId string) (credit.CreditMetadata, error) {
-	// vvv credit-related NMDC schema types vvv
-
-	// https://microbiomedata.github.io/nmdc-schema/PersonValue/
-	type PersonValue struct {
-		Email    string   `json:"email,omitempty"`
-		Name     string   `json:"name,omitempty"`
-		Orcid    string   `json:"orcid,omitempty"`
-		Websites []string `json:"websites,omitempty"`
-		RawValue string   `json:"has_raw_value,omitempty"` // name in 'FIRST LAST' format (if present)
-	}
-
-	// https://microbiomedata.github.io/nmdc-schema/CreditAssociation/
-	type CreditAssociation struct {
-		Roles  []string    `json:"applied_roles"`
-		Person PersonValue `json:"applies_to_person"`
-		Type   string      `json:"type,omitempty"`
-	}
-
-	// https://microbiomedata.github.io/nmdc-schema/Doi/
-	type Doi struct {
-		Value    string `json:"doi_value"`
-		Provider string `json:"doi_provider,omitempty"`
-		Category string `json:"doi_category"`
-	}
-
-	// https://microbiomedata.github.io/nmdc-schema/Study/
-	type Study struct { // partial representation, includes only relevant fields
-		Id                 string              `json:"id"`
-		AlternativeNames   []string            `json:"alternative_names,omitempty"`
-		AlternativeTitles  []string            `json:"alternative_titles,omitempty"`
-		AssociatedDois     []Doi               `json:"associated_dois,omitempty"`
-		Description        string              `json:"description,omitempty"`
-		FundingSources     []string            `json:"funding_sources,omitempty"`
-		CreditAssociations []CreditAssociation `json:"has_credit_associations,omitempty"`
-		Name               string              `json:"name,omitempty"`
-		RelatedIdentifiers string              `json:"related_identifiers,omitempty"`
-		Title              string              `json:"title,omitempty"`
-	}
-
-	// fetch the study with the given ID
-	var creditMetadata credit.CreditMetadata
-	body, err := db.get(fmt.Sprintf("studies/%s", studyId), url.Values{})
-	if err != nil {
-		return creditMetadata, err
-	}
-	var study Study
-	err = json.Unmarshal(body, &study)
-	if err != nil {
-		return creditMetadata, err
-	}
-
-	// fish metadata out of the study
-
+// extracts credit metadata from the given study
+func (db Database) creditMetadataForStudy(study Study) credit.CreditMetadata {
 	// NOTE: principal investigator role is included with credit associations
 	contributors := make([]credit.Contributor, len(study.CreditAssociations))
 	for i, association := range study.CreditAssociations {
@@ -810,8 +708,7 @@ func (db Database) creditMetadataForStudy(studyId string) (credit.CreditMetadata
 		}
 	}
 
-	creditMetadata = credit.CreditMetadata{
-		// Identifier, Dates, and Version fields are specific to DataResources, omitted here
+	return credit.CreditMetadata{
 		Contributors: contributors,
 		Funding:      fundingSources,
 		Publisher: credit.Organization{
@@ -822,88 +719,6 @@ func (db Database) creditMetadataForStudy(studyId string) (credit.CreditMetadata
 		ResourceType:       "dataset",
 		Titles:             titles,
 	}
-	// FIXME: we can probably chase down credit metadata dates using the
-	// FIXME: generated_by (Activity) field, instantiated as one of the
-	// FIXME: concrete types listed here: https://microbiomedata.github.io/nmdc-schema/WorkflowExecutionActivity/
-
-	return creditMetadata, err
-}
-
-// fetches biosample (JSON) metadata for the given study
-func (db *Database) biosampleMetadataForStudy(studyId string) (json.RawMessage, error) {
-	var results json.RawMessage
-	var p url.Values
-	p.Add("associated_studies", studyId)
-	body, err := db.get("biosamples", p)
-	if err != nil {
-		return results, err
-	}
-	err = json.Unmarshal(body, &results)
-	return results, err
-}
-
-// fetches file metadata for data objects associated with the given study
-func (db Database) dataObjectsForStudy(studyId string, params url.Values) (databases.SearchResults, error) {
-	var results databases.SearchResults
-
-	body, err := db.get(fmt.Sprintf("data_objects/study/%s", studyId), params)
-	if err != nil {
-		return results, err
-	}
-
-	type DataObjectsByStudyResults struct {
-		BiosampleId string       `json:"biosample_id"`
-		DataObjects []DataObject `json:"data_objects"`
-	}
-	var objectSets []DataObjectsByStudyResults
-	err = json.Unmarshal(body, &objectSets)
-	if err != nil {
-		return results, err
-	}
-
-	// FIXME: I'm not able to get filters to work as (seems to be) intended, so
-	// FIXME: this is a short-term hack.
-	var dataObjectType string
-	if params.Has("filter") {
-		filter := params.Get("filter")
-		colon := strings.Index(filter, ":")
-		if strings.Contains(filter, "data_object_type:") {
-			dataObjectType = filter[colon+1:]
-		}
-	}
-
-	// create Frictionless descriptors for the data objects
-	results.Descriptors = make([]map[string]interface{}, 0)
-	for _, objectSet := range objectSets {
-		for _, dataObject := range objectSet.DataObjects {
-			// FIXME: apply hack!
-			if dataObjectType != "" && dataObject.DataObjectType != dataObjectType {
-				slog.Debug(fmt.Sprintf("Data object type mismatch (want %s, got %s)", dataObjectType, dataObject.DataObjectType))
-				continue
-			}
-			descriptor := db.descriptorFromDataObject(dataObject)
-			results.Descriptors = append(results.Descriptors, descriptor)
-		}
-	}
-
-	// fill in study-level credit metadata for each resource
-	studyCreditMetadata, err := db.creditMetadataForStudy(studyId)
-	if err != nil {
-		return results, err
-	}
-	for i, descriptor := range results.Descriptors {
-		credit := descriptor["credit"].(credit.CreditMetadata)
-		credit.Contributors = studyCreditMetadata.Contributors
-		credit.Funding = studyCreditMetadata.Funding
-		credit.Publisher = studyCreditMetadata.Publisher
-		credit.RelatedIdentifiers = studyCreditMetadata.RelatedIdentifiers
-		credit.ResourceType = studyCreditMetadata.ResourceType
-		credit.Titles = studyCreditMetadata.Titles
-		descriptor["credit"] = credit
-		results.Descriptors[i] = descriptor
-	}
-
-	return results, nil
 }
 
 // returns the page number and page size corresponding to the given Pagination

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -106,9 +106,9 @@ func TestDescriptors(t *testing.T) {
 	}
 	descriptors, err := db.Descriptors(orcid, fileIds[:10])
 	assert.Nil(err, "NMDC resource query encountered an error")
-	assert.Equal(10, len(descriptors),
-		"NMDC resource query didn't return requested number of results")
-	for i, desc := range descriptors {
+	assert.True(len(descriptors) >= 10, // can include biosample metadata!
+		"NMDC resource query didn't return all results")
+	for i, desc := range descriptors[:10] {
 		nmdcSearchResult := results.Descriptors[i]
 		assert.Equal(nmdcSearchResult["id"], desc["id"], "Resource ID mismatch")
 		assert.Equal(nmdcSearchResult["name"], desc["name"], "Resource name mismatch")

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -22,8 +22,6 @@
 package endpoints
 
 import (
-	"fmt"
-
 	"github.com/google/uuid"
 
 	"github.com/kbase/dts/config"
@@ -94,7 +92,7 @@ var createEndpointFuncs = make(map[string]func(name string) (Endpoint, error))
 // to allow for e.g. test database implementations
 func RegisterEndpointProvider(provider string, createEp func(name string) (Endpoint, error)) error {
 	if _, found := createEndpointFuncs[provider]; found {
-		return fmt.Errorf("Cannot register endpoint provider %s (already registered)", provider)
+		return &AlreadyRegisteredError{Provider: provider}
 	} else {
 		createEndpointFuncs[provider] = createEp
 		return nil

--- a/endpoints/errors.go
+++ b/endpoints/errors.go
@@ -43,3 +43,13 @@ func (e InvalidProviderError) Error() string {
 	return fmt.Sprintf("The endpoint '%s' has an invalid provider: '%s'.",
 		e.Name, e.Provider)
 }
+
+// indicates that an endpoint provider is already registered and an attempt has
+// been made to register it again
+type AlreadyRegisteredError struct {
+	Provider string
+}
+
+func (e AlreadyRegisteredError) Error() string {
+	return fmt.Sprintf("Cannot register endpoint provider '%s': already registered", e.Provider)
+}

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -442,7 +442,7 @@ func searchDatabase(_ context.Context,
 	// is the database valid?
 	_, ok := config.Databases[input.Database]
 	if !ok {
-		return nil, databaseError(databases.NotFoundError{Database: input.Database})
+		return nil, databaseError(&databases.NotFoundError{Database: input.Database})
 	}
 
 	// check the requested file status

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/kbase/dts/config"
 	"github.com/kbase/dts/dtstest"
+	"github.com/kbase/dts/endpoints"
+	"github.com/kbase/dts/endpoints/local"
 )
 
 // working directory from which the tests were invoked
@@ -166,9 +168,22 @@ func setup() {
 	}
 
 	// register test databases referred to in config file
-	dtstest.RegisterDatabase("source", testDescriptors)
-	dtstest.RegisterDatabase("destination1", nil)
-	dtstest.RegisterDatabase("destination2", nil)
+	err = endpoints.RegisterEndpointProvider("local", local.NewEndpoint)
+	if err != nil {
+		log.Panicf("Couldn't initialize configuration: %s", err)
+	}
+	err = dtstest.RegisterDatabase("source", testDescriptors)
+	if err != nil {
+		log.Panicf("Couldn't initialize configuration: %s", err)
+	}
+	err = dtstest.RegisterDatabase("destination1", nil)
+	if err != nil {
+		log.Panicf("Couldn't initialize configuration: %s", err)
+	}
+	err = dtstest.RegisterDatabase("destination2", nil)
+	if err != nil {
+		log.Panicf("Couldn't initialize configuration: %s", err)
+	}
 
 	// create the DTS data and manifest directories
 	os.Mkdir(config.Service.DataDirectory, 0755)

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -73,16 +73,31 @@ func Start() error {
 	// if this is the first call to Start(), register our built-in endpoint
 	// and database providers
 	if firstCall {
-		endpoints.RegisterEndpointProvider("globus", globus.NewEndpoint)
-		endpoints.RegisterEndpointProvider("local", local.NewEndpoint)
+		err := endpoints.RegisterEndpointProvider("globus", globus.NewEndpoint)
+		if err != nil {
+			return err
+		}
+		err = endpoints.RegisterEndpointProvider("local", local.NewEndpoint)
+		if err != nil {
+			return err
+		}
 		if _, found := config.Databases["jdp"]; found {
-			databases.RegisterDatabase("jdp", jdp.NewDatabase)
+			err = databases.RegisterDatabase("jdp", jdp.NewDatabase)
+			if err != nil {
+				return err
+			}
 		}
 		if _, found := config.Databases["kbase"]; found {
-			databases.RegisterDatabase("kbase", kbase.NewDatabase)
+			err = databases.RegisterDatabase("kbase", kbase.NewDatabase)
+			if err != nil {
+				return err
+			}
 		}
 		if _, found := config.Databases["nmdc"]; found {
-			databases.RegisterDatabase("nmdc", nmdc.NewDatabase)
+			err = databases.RegisterDatabase("nmdc", nmdc.NewDatabase)
+			if err != nil {
+				return err
+			}
 		}
 		firstCall = false
 	}

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -67,7 +67,7 @@ const (
 // informative error if anything prevents this
 func Start() error {
 	if running {
-		return AlreadyRunningError{}
+		return &AlreadyRunningError{}
 	}
 
 	// if this is the first call to Start(), register our built-in endpoint
@@ -139,7 +139,7 @@ func Stop() error {
 		err = <-taskChannels.Error
 		running = false
 	} else {
-		err = NotRunningError{}
+		err = &NotRunningError{}
 	}
 	return err
 }
@@ -177,7 +177,7 @@ func Create(spec Specification) (uuid.UUID, error) {
 
 	// have we requested files to be transferred?
 	if len(spec.FileIds) == 0 {
-		return taskId, NoFilesRequestedError{}
+		return taskId, &NoFilesRequestedError{}
 	}
 
 	// verify that we can fetch the task's source and destination databases
@@ -364,14 +364,14 @@ func processTasks() {
 					tasks[task.Id] = task
 				}
 			} else {
-				err := NotFoundError{Id: taskId}
+				err := &NotFoundError{Id: taskId}
 				errorChan <- err
 			}
 		case taskId := <-getTaskStatusChan: // Status() called
 			if task, found := tasks[taskId]; found {
 				returnTaskStatusChan <- task.Status
 			} else {
-				err := NotFoundError{Id: taskId}
+				err := &NotFoundError{Id: taskId}
 				errorChan <- err
 			}
 		case <-pollChan: // time to move things along

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -73,13 +73,16 @@ func Start() error {
 	// if this is the first call to Start(), register our built-in endpoint
 	// and database providers
 	if firstCall {
+		// NOTE: it's okay if these endpoint providers have already been registered,
+		// NOTE: as they can be used in testing
 		err := endpoints.RegisterEndpointProvider("globus", globus.NewEndpoint)
-		if err != nil {
-			return err
+		if err == nil {
+			err = endpoints.RegisterEndpointProvider("local", local.NewEndpoint)
 		}
-		err = endpoints.RegisterEndpointProvider("local", local.NewEndpoint)
 		if err != nil {
-			return err
+			if _, matches := err.(*endpoints.AlreadyRegisteredError); !matches {
+				return err
+			}
 		}
 		if _, found := config.Databases["jdp"]; found {
 			err = databases.RegisterDatabase("jdp", jdp.NewDatabase)


### PR DESCRIPTION
This PR creates a distinction between "file" and "data" descriptors. The former category includes descriptors that (ehm) describe files to be moved in transfers, whereas the latter includes in-line data which is placed into the transfer manifest. This lets us include NMDC biosample metadata, which is not stored in files within NMDC. These metadata are stored in a simple JSON format which is transplanted to the manifest as is.

**Update:** well, that was fun. I'm sure there are still some minor issues remaining, but I think we at least know how we are expected to retrieve credit and biosample metadata related to data objects now. Of note:
* We extract these metadata via a new endpoint that relies on each data object's workflow execution ID.
* Analysis data objects have workflow execution IDs, but raw data objects **do not**. Says Alicia Clum of this:  "If it is the raw data, not sure why you'd want this b/c NMDC isn't supposed to be a 'data repository'."
* For search by study, we start by fetching the study's metadata and then we get all the data objects from the study--two API calls total, since we don't need biosample metadata. This is pretty zippy.
* For filtered search and by-file-id lookup, the only way to get a file's metadata is by looking it up via the file's workflow execution ID (where it exists). In testing, I've found that often each file has its own workflow execution ID. Tracing metadata for each file needs a network roundtrip for each file, regardless of whether multiple files belong to the same study, because _we just don't know_. So these queries can take a while. It may not matter too much, because by-file-id lookup is used only to check whether files are staged, and during the transfer process (which is also slow!). But it still feels suboptimal.

Anyway: onward!