### PR TITLE
Added super-users to DTS authenticator and an "off-menu" custom transfer destination feature

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -41,12 +41,14 @@ type Client struct {
 // (but should have a KBase account if they are requesting files be transferred
 // to KBase).
 type User struct {
-	// client name (human-readable and display-friendly)
+	// name (human-readable and display-friendly)
 	Name string
-	// client email address
+	// email address
 	Email string
 	// ORCID identifier associated with this user
 	Orcid string
 	// organization with which this user is affiliated
 	Organization string
+	// true if this user is a Superuser
+	IsSuper bool
 }

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/fernet/fernet-go"
@@ -96,7 +97,7 @@ func (a *Authenticator) readAccessTokenFile() error {
 	reader := csv.NewReader(bytes.NewReader(plaintext))
 	reader.Comma = '\t'
 	reader.Comment = '#'
-	reader.FieldsPerRecord = 5
+	reader.FieldsPerRecord = 6
 
 	records, err := reader.ReadAll()
 	if err != nil {
@@ -106,11 +107,20 @@ func (a *Authenticator) readAccessTokenFile() error {
 	userRecords := make(map[string]User)
 	for _, record := range records {
 		token := record[4]
+
+		// superuser column: interpret "truthy" and "falsey" values as booleans
+		var isSuper bool
+		switch strings.ToLower(record[5]) {
+		case "1", "true":
+			isSuper = true
+		}
+
 		userRecords[token] = User{
 			Name:         record[0],
 			Email:        record[1],
 			Orcid:        record[2],
 			Organization: record[3],
+			IsSuper:      isSuper,
 		}
 	}
 

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -92,8 +92,8 @@ func setup() {
 
 	// write an access TSV file and encrypt it with a secret
 	// (fictitious orcid record: https://orcid.org/0000-0002-1825-0097)
-	plaintext := fmt.Sprintf("# Name | Email | Orcid | Organization | Token\n"+
-		"%s\t%s\t%s\t%s\t%s\n",
+	plaintext := fmt.Sprintf("# Name | Email | Orcid | Organization | Token | Superuser\n"+
+		"%s\t%s\t%s\t%s\t%s\tfalse\n",
 		TestUser.Name, TestUser.Email, TestUser.Orcid,
 		TestUser.Organization, TestAccessToken)
 	token, err := fernet.EncryptAndSign([]byte(plaintext), &TestKey)

--- a/config/credential_config.go
+++ b/config/credential_config.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package config
+
+type credentialConfig struct {
+	// the ID used for authentication (username or UUID)
+	Id string `yaml:"id"`
+	// the secret used for authentication (e.g. password)
+	// DO NOT STORE THIS IN A CONFIG FILE! Use an environment variable instead
+	Secret string `yaml:"secret"`
+}

--- a/config/endpoint_config.go
+++ b/config/endpoint_config.go
@@ -11,8 +11,8 @@ type endpointConfig struct {
 	Id uuid.UUID `yaml:"id"`
 	// the name of the provider (e.g. "globus")
 	Provider string `yaml:"provider"`
-	// authentication/authorization data (client secret used to request access token)
-	Auth authConfig `yaml:"auth,omitempty"`
+	// the name of the credential to use with this endpoint
+	Credential string `yaml:"credential"`
 	// root directory for filesystem access (optional)
 	Root string `yaml:"root,omitempty"`
 }

--- a/config/errors.go
+++ b/config/errors.go
@@ -34,6 +34,15 @@ func (e InvalidServiceConfigError) Error() string {
 	return fmt.Sprintf("Invalid service configuration: %s", e.Message)
 }
 
+// indicates that a credential is not configured properly
+type InvalidCredentialConfigError struct {
+	Credential, Message string
+}
+
+func (e InvalidCredentialConfigError) Error() string {
+	return fmt.Sprintf("Credential %s is not properly configured: %s", e.Credential, e.Message)
+}
+
 // indicates that an endpoint is not configured properly
 type InvalidEndpointConfigError struct {
 	Endpoint, Message string

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -471,7 +471,7 @@ func descriptorFromOrganismAndFile(organism Organism, file File) map[string]any 
 		"path":      filePath,
 		"format":    format,
 		"mediatype": mimetypeForFile(file.Name),
-		"bytes":     file.Size,
+		"bytes":     int(file.Size),
 		"hash":      file.MD5Sum,
 		"credit": credit.CreditMetadata{
 			Identifier:   id,

--- a/databases/jdp/database_test.go
+++ b/databases/jdp/database_test.go
@@ -35,7 +35,7 @@ func setup() {
 	dtstest.EnableDebugLogging()
 	config.Init([]byte(jdpConfig))
 	databases.RegisterDatabase("jdp", NewDatabase)
-	endpoints.RegisterEndpointProvider("globus", globus.NewEndpoint)
+	endpoints.RegisterEndpointProvider("globus", globus.NewEndpointFromConfig)
 }
 
 // this function gets called after all tests have been run

--- a/databases/jdp/file.go
+++ b/databases/jdp/file.go
@@ -38,8 +38,8 @@ type File struct {
 	Name string `json:"file_name"`
 	// directory in which the file sits
 	Path string `json:"file_path"`
-	// file size (bytes)
-	Size int `json:"file_size"`
+	// file size (bytes) -- perversely, can be an integer or float value, so we store as float
+	Size float64 `json:"file_size"`
 	// file metadata
 	Metadata Metadata `json:"metadata"`
 	// name of the user that owns the file

--- a/databases/kbase/database_test.go
+++ b/databases/kbase/database_test.go
@@ -200,7 +200,7 @@ func setup() {
 	copyDataFile("good_user_table_0.csv", kbaseUserTableFile)
 
 	databases.RegisterDatabase("kbase", NewDatabase)
-	endpoints.RegisterEndpointProvider("globus", globus.NewEndpoint)
+	endpoints.RegisterEndpointProvider("globus", globus.NewEndpointFromConfig)
 }
 
 // copies a file from a source to a destination file within the DTS data directory

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -57,7 +57,7 @@ func setup() {
 	dtstest.EnableDebugLogging()
 	config.Init([]byte(nmdcConfig))
 	databases.RegisterDatabase("nmdc", NewDatabase)
-	endpoints.RegisterEndpointProvider("globus", globus.NewEndpoint)
+	endpoints.RegisterEndpointProvider("globus", globus.NewEndpointFromConfig)
 
 	// construct NMDC-specific search parameters for a study
 	nmdcSearchParams = make(map[string]any)

--- a/deployment/dts.yaml
+++ b/deployment/dts.yaml
@@ -39,46 +39,41 @@ service:
   delete_after: ${PURGE_INTERVAL}
   debug: ${DEBUG}
 
+credentials:
+  globus:
+    id: ${GLOBUS_CLIENT_ID}
+    secret: ${GLOBUS_CLIENT_SECRET}
+
 endpoints:
   globus-local:
     name: DTS Local Endpoint
     id: ${LOCAL_ENDPOINT_ID}
     provider: globus
-    auth:
-      client_id: ${GLOBUS_CLIENT_ID}
-      client_secret: ${GLOBUS_CLIENT_SECRET}
+    credential: globus
   globus-jdp:
     name: DTS JGI Share
     id: ${JDP_ENDPOINT_ID}
     provider: globus
+    credential: globus
     root: /dm_archive
-    auth:
-      client_id: ${GLOBUS_CLIENT_ID}
-      client_secret: ${GLOBUS_CLIENT_SECRET}
   globus-kbase:
     name: KBase Bulk Share
     id: ${KBASE_ENDPOINT_ID}
     provider: globus
+    credential: globus
     root: /jeff_cohere
-    auth:
-      client_id: ${GLOBUS_CLIENT_ID}
-      client_secret: ${GLOBUS_CLIENT_SECRET}
   globus-nmdc-nersc:
     name: NMDC (NERSC)
     id: ${NMDC_NERSC_ENDPOINT_ID}
     provider: globus
+    credential: globus
     root: /
-    auth:
-      client_id: ${GLOBUS_CLIENT_ID}
-      client_secret: ${GLOBUS_CLIENT_SECRET}
   globus-nmdc-emsl:
     name: NMDC Bulk Data Cache
     id: ${NMDC_EMSL_ENDPOINT_ID}
     provider: globus
+    credential: globus
     root: /
-    auth:
-      client_id: ${GLOBUS_CLIENT_ID}
-      client_secret: ${GLOBUS_CLIENT_SECRET}
 
 databases: # databases between which files can be transferred
   jdp:

--- a/dts.yaml.example
+++ b/dts.yaml.example
@@ -15,28 +15,27 @@ service:
                              # is deleted (seconds)
   debug: true                # set to enable debug-level logging and other tools
 
+credentials:
+  globus:
+    id: <credential ID (username, UUID, etc)>
+    secret: <secret/password>
+
 endpoints: # file transfer endpoints
   globus-local:
     name: name-of-endpoint                   # usually Globus display name
     id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # Unique globus endpoint ID
     provider: globus                         # endpoint provider (globus, ???)
-    auth:
-      client_id: <ID of client with authentication secret>
-      client_secret: <secret>
+    credential: globus
   globus-jdp:
     name: name-of-endpoint                   # usually Globus display name
     id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # Unique globus endpoint ID
     provider: globus                         # endpoint provider (globus, ???)
-    auth:
-      client_id: <ID of client with authentication secret>
-      client_secret: <secret>
+    credential: globus
   globus-kbase:
     name: name-of-endpoint                   # usually Globus display name
     id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # Unique globus endpoint ID
     provider: globus                         # endpoint provider (globus, ???)
-    auth:
-      client_id: <ID of client with authentication secret>
-      client_secret: <secret>
+    credential: globus
 
 databases: # databases between which files can be transferred
   jdp:                                   # JGI data portal configuration

--- a/dtstest/dtstest.go
+++ b/dtstest/dtstest.go
@@ -121,6 +121,10 @@ func RegisterEndpoint(endpointName string, options EndpointOptions) error {
 	return endpoints.RegisterEndpointProvider(provider, newEndpointFunc)
 }
 
+func (ep *Endpoint) Provider() string {
+	return "dtstest"
+}
+
 func (ep *Endpoint) Root() string {
 	return ep.RootPath
 }

--- a/endpoints/custom.go
+++ b/endpoints/custom.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2023 The KBase Project and its Contributors
+// Copyright (c) 2023 Cohere Consulting, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package endpoints
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/kbase/dts/config"
+)
+
+// A custom endpoint specification encoded in a string of the form "<provider>:<id>:<credential>",
+// where
+// * provider is the name of a tranport service (e.g. "globus") as in the config file
+// * id is a corresponding identifier for the destination (e.g. a UUID for a Globus share)
+// * credential is the name of a credential stored in the config file
+type CustomSpec struct {
+	Provider, Id, Credential string
+}
+
+// parses the string into a CustomSpec, returning an error if the spec is invalid
+func ParseCustomSpec(s string) (CustomSpec, error) {
+	terms := strings.Split(s, ":")
+	if len(terms) != 3 {
+		return CustomSpec{}, &InvalidCustomSpecError{
+			String:  s,
+			Message: "does not match form <provider>:<id>:<credential>",
+		}
+	}
+	customSpec := CustomSpec{
+		Provider:   terms[0],
+		Id:         terms[1],
+		Credential: terms[2],
+	}
+
+	// for now, custom destinations must be Globus shares
+	if customSpec.Provider != "globus" {
+		return CustomSpec{}, &InvalidCustomSpecError{
+			String:  s,
+			Message: fmt.Sprintf("invalid provider: %s", customSpec.Provider),
+		}
+	}
+
+	// Globus shares are identified by UUIDs
+	_, err := uuid.Parse(customSpec.Id)
+	if err != nil {
+		return CustomSpec{}, &InvalidCustomSpecError{
+			String:  s,
+			Message: fmt.Sprintf("invalid ID: %s", customSpec.Id),
+		}
+	}
+
+	// do we have a valid credential?
+	_, validCredential := config.Credentials[customSpec.Credential]
+	if !validCredential {
+		return CustomSpec{}, &InvalidCustomSpecError{
+			String:  s,
+			Message: fmt.Sprintf("invalid credential: %s", customSpec.Credential),
+		}
+	}
+
+	return customSpec, nil
+}

--- a/endpoints/custom.go
+++ b/endpoints/custom.go
@@ -36,22 +36,23 @@ import (
 // * id is a corresponding identifier for the destination (e.g. a UUID for a Globus share)
 // * credential is the name of a credential stored in the config file
 type CustomSpec struct {
-	Provider, Id, Credential string
+	Provider, Id, Path, Credential string
 }
 
 // parses the string into a CustomSpec, returning an error if the spec is invalid
 func ParseCustomSpec(s string) (CustomSpec, error) {
 	terms := strings.Split(s, ":")
-	if len(terms) != 3 {
+	if len(terms) != 4 {
 		return CustomSpec{}, &InvalidCustomSpecError{
 			String:  s,
-			Message: "does not match form <provider>:<id>:<credential>",
+			Message: "does not match form <provider>:<id>:<path>:<credential>",
 		}
 	}
 	customSpec := CustomSpec{
 		Provider:   terms[0],
 		Id:         terms[1],
-		Credential: terms[2],
+		Path:       terms[2],
+		Credential: terms[3],
 	}
 
 	// for now, custom destinations must be Globus shares

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -65,6 +65,8 @@ type TransferStatus struct {
 
 // This type represents an endpoint for transferring files.
 type Endpoint interface {
+	// returns a string indicating the service provider for the endpoint
+	Provider() string
 	// returns the path on the file system that serves as the endpoint's root
 	Root() string
 	// returns true if the files associated with the given Frictionless

--- a/endpoints/errors.go
+++ b/endpoints/errors.go
@@ -44,6 +44,16 @@ func (e InvalidProviderError) Error() string {
 		e.Name, e.Provider)
 }
 
+// indicates that a custom endpoint (string) specification is invalid
+type InvalidCustomSpecError struct {
+	String, Message string
+}
+
+func (e InvalidCustomSpecError) Error() string {
+	return fmt.Sprintf("The custom endpoint specification '%s' is invalid: '%s'.",
+		e.String, e.Message)
+}
+
 // indicates that an endpoint provider is already registered and an attempt has
 // been made to register it again
 type AlreadyRegisteredError struct {

--- a/endpoints/errors.go
+++ b/endpoints/errors.go
@@ -68,9 +68,14 @@ func (e AlreadyRegisteredError) Error() string {
 type IncompatibleDestinationError struct {
 	Source, SourceProvider           string
 	Destination, DestinationProvider string
+	Message                          string
 }
 
 func (e IncompatibleDestinationError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("The source endpoint '%s' (%s) cannot transfer files to the destination endpoint '%s' (%s): %s",
+			e.Source, e.SourceProvider, e.Destination, e.DestinationProvider, e.Message)
+	}
 	return fmt.Sprintf("The source endpoint '%s' (%s) cannot transfer files to the destination endpoint '%s' (%s)",
 		e.Source, e.SourceProvider, e.Destination, e.DestinationProvider)
 }

--- a/endpoints/errors.go
+++ b/endpoints/errors.go
@@ -63,3 +63,14 @@ type AlreadyRegisteredError struct {
 func (e AlreadyRegisteredError) Error() string {
 	return fmt.Sprintf("Cannot register endpoint provider '%s': already registered", e.Provider)
 }
+
+// indicates that a source endpoint has been asked to transfer files to an incompatible destination
+type IncompatibleDestinationError struct {
+	Source, SourceProvider           string
+	Destination, DestinationProvider string
+}
+
+func (e IncompatibleDestinationError) Error() string {
+	return fmt.Sprintf("The source endpoint '%s' (%s) cannot transfer files to the destination endpoint '%s' (%s)",
+		e.Source, e.SourceProvider, e.Destination, e.DestinationProvider)
+}

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -133,6 +133,10 @@ func NewEndpointFromConfig(endpointName string) (endpoints.Endpoint, error) {
 	return NewEndpoint(epConfig.Name, epConfig.Id, epConfig.Root, clientId, credential.Secret)
 }
 
+func (ep *Endpoint) Provider() string {
+	return "globus"
+}
+
 func (ep *Endpoint) Root() string {
 	return ep.RootDir
 }

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -77,6 +77,9 @@ type Endpoint struct {
 	// authentication stuff
 	ClientId     uuid.UUID
 	ClientSecret string
+
+	// endpoint configuration
+	Info EndpointInfo
 }
 
 // creates a new Globus endpoint using the given information
@@ -109,7 +112,11 @@ func NewEndpoint(name string, shareId uuid.UUID, rootPath string, clientId uuid.
 	slog.Debug(fmt.Sprintf("Endpoint %s: root directory is %s",
 		name, rootPath))
 
-	return ep, nil
+	// query the endpoint for its capabilities
+	var err error
+	ep.Info, err = ep.getEndpointInfo(ep.Id)
+
+	return ep, err
 }
 
 // creates a new Globus endpoint using the information supplied in the
@@ -567,11 +574,32 @@ func (ep *Endpoint) getSubmissionId() (uuid.UUID, error) {
 	return response.Value, err
 }
 
+// https://docs.globus.org/api/transfer/endpoints_and_collections/#get_endpoint_or_collection_by_id
 // https://docs.globus.org/api/transfer/task_submit/#submit_transfer_task
 // https://docs.globus.org/api/transfer/task_submit/#transfer_item_fields
 func (ep *Endpoint) submitTransfer(destination endpoints.Endpoint,
 	submissionId uuid.UUID, files []endpoints.FileTransfer) (uuid.UUID, error) {
 	var xferId uuid.UUID
+
+	// are the source and destination endpoints configured in a conflicting way?
+	globusDestination := destination.(*Endpoint)
+	if ep.Info.ForceVerify && globusDestination.Info.DisableVerify { // not allowed!
+		return xferId, &endpoints.IncompatibleDestinationError{
+			Source:              ep.Name,
+			SourceProvider:      "globus",
+			Destination:         globusDestination.Name,
+			DestinationProvider: "globus",
+			Message:             "Source endpoint forces checksum verification, but destination disables it.",
+		}
+	}
+
+	// configure checksum settings based on destination endpoint info
+	var verifyChecksum bool = true
+	var syncLevel int = 3                     // transfer only if checksums don't match
+	if globusDestination.Info.DisableVerify { // checksum verification disabled on endpoint
+		verifyChecksum = false
+		syncLevel = 2 // transfer if source file is newer than destination file
+	}
 
 	type TransferItem struct {
 		DataType          string `json:"DATA_TYPE"` // "transfer_item"
@@ -580,6 +608,29 @@ func (ep *Endpoint) submitTransfer(destination endpoints.Endpoint,
 		ExternalChecksum  string `json:"external_checksum,omitempty"`
 		ChecksumAlgorithm string `json:"checksum_algorithm,omitempty"`
 	}
+	xferItems := make([]TransferItem, len(files))
+	for i, file := range files {
+		var checksum, checksumAlgorithm string
+		if verifyChecksum {
+			checksum = file.Hash
+			checksumAlgorithm = file.HashAlgorithm
+		}
+		xferItems[i] = TransferItem{
+			DataType:          "transfer_item",
+			SourcePath:        filepath.Join(ep.RootDir, file.SourcePath),
+			DestinationPath:   file.DestinationPath,
+			ExternalChecksum:  checksum,
+			ChecksumAlgorithm: checksumAlgorithm,
+		}
+	}
+
+	// the destination is a Globus endpoint, right?
+	gDestination, ok := destination.(*Endpoint)
+	if !ok {
+		return xferId, fmt.Errorf("The destination is not a Globus endpoint.")
+	}
+
+	// submit the transfer request
 	type SubmissionRequest struct {
 		DataType            string         `json:"DATA_TYPE"` // "transfer"
 		Id                  string         `json:"submission_id"`
@@ -591,23 +642,6 @@ func (ep *Endpoint) submitTransfer(destination endpoints.Endpoint,
 		VerifyChecksum      bool           `json:"verify_checksum"`
 		FailOnQuotaErrors   bool           `json:"fail_on_quota_errors"`
 	}
-	xferItems := make([]TransferItem, len(files))
-	for i, file := range files {
-		xferItems[i] = TransferItem{
-			DataType:          "transfer_item",
-			SourcePath:        filepath.Join(ep.RootDir, file.SourcePath),
-			DestinationPath:   file.DestinationPath,
-			ExternalChecksum:  file.Hash,
-			ChecksumAlgorithm: file.HashAlgorithm,
-		}
-	}
-
-	// the destination is a Globus endpoint, right?
-	gDestination, ok := destination.(*Endpoint)
-	if !ok {
-		return xferId, fmt.Errorf("The destination is not a Globus endpoint.")
-	}
-
 	data, err := json.Marshal(SubmissionRequest{
 		DataType:            "transfer",
 		Id:                  submissionId.String(),
@@ -615,8 +649,8 @@ func (ep *Endpoint) submitTransfer(destination endpoints.Endpoint,
 		Data:                xferItems,
 		DestinationEndpoint: gDestination.Id.String(),
 		SourceEndpoint:      ep.Id.String(),
-		SyncLevel:           3, // transfer only if checksums don't match
-		VerifyChecksum:      true,
+		SyncLevel:           syncLevel,
+		VerifyChecksum:      verifyChecksum,
 		FailOnQuotaErrors:   true,
 	})
 	if err != nil {
@@ -647,4 +681,28 @@ func (ep *Endpoint) submitTransfer(destination endpoints.Endpoint,
 	slog.Debug(fmt.Sprintf("Initiated Globus transfer task %s (%d files)",
 		xferId.String(), len(files)))
 	return xferId, nil
+}
+
+type EndpointInfo struct {
+	DisableVerify bool `json:"disable_verify"` // true if checksums are not available
+	ForceVerify   bool `json:"force_verify"`   // true if checksums must be available
+}
+
+func (ep *Endpoint) getEndpointInfo(id uuid.UUID) (EndpointInfo, error) {
+	// query the endpoint for its capabilities
+	body, err := ep.get(fmt.Sprintf("endpoint/%s", id), url.Values{})
+	if err != nil {
+		return EndpointInfo{}, err
+	}
+	if responseIsError(body) {
+		var globusErr GlobusError
+		err = json.Unmarshal(body, &globusErr)
+		if err == nil {
+			err = &globusErr
+		}
+		return EndpointInfo{}, err
+	}
+	var endpointInfo EndpointInfo
+	err = json.Unmarshal(body, &endpointInfo)
+	return endpointInfo, err
 }

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -89,14 +89,22 @@ func NewEndpoint(endpointName string) (endpoints.Endpoint, error) {
 	if epConfig.Provider != "globus" {
 		return nil, fmt.Errorf("'%s' is not a Globus endpoint", endpointName)
 	}
+	credential, found := config.Credentials[epConfig.Credential]
+	if !found {
+		return nil, fmt.Errorf("Invalid credential for endpoint '%s': %s", endpointName, epConfig.Credential)
+	}
+	clientId, err := uuid.Parse(credential.Id)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid Globus client ID for credential '%s': %s (must be UUID)", epConfig.Credential, credential.Id)
+	}
 
 	defaultScopes := []string{"urn:globus:auth:scope:transfer.api.globus.org:all"}
 	ep := &Endpoint{
 		Name:         epConfig.Name,
 		Id:           epConfig.Id,
 		Scopes:       defaultScopes,
-		ClientId:     epConfig.Auth.ClientId,
-		ClientSecret: epConfig.Auth.ClientSecret,
+		ClientId:     clientId,
+		ClientSecret: credential.Secret,
 	}
 
 	// if needed, authenticate to obtain a Globus Transfer API access token

--- a/endpoints/globus/endpoint_test.go
+++ b/endpoints/globus/endpoint_test.go
@@ -95,7 +95,7 @@ func breakdown() {
 func TestGlobusConstructor(t *testing.T) {
 	assert := assert.New(t)
 
-	endpoint, err := NewEndpoint("source")
+	endpoint, err := NewEndpointFromConfig("source")
 	assert.NotNil(endpoint)
 	assert.Nil(err)
 }
@@ -103,14 +103,14 @@ func TestGlobusConstructor(t *testing.T) {
 func TestBadGlobusConstructor(t *testing.T) {
 	assert := assert.New(t)
 
-	endpoint, err := NewEndpoint("not-globus-jdp")
+	endpoint, err := NewEndpointFromConfig("not-globus-jdp")
 	assert.Nil(endpoint)
 	assert.NotNil(err)
 }
 
 func TestGlobusTransfers(t *testing.T) {
 	assert := assert.New(t)
-	endpoint, _ := NewEndpoint("source")
+	endpoint, _ := NewEndpointFromConfig("source")
 	// this is just a smoke test--we don't check the contents of the result
 	xfers, err := endpoint.Transfers()
 	assert.NotNil(xfers) // empty or non-empty slice
@@ -119,7 +119,7 @@ func TestGlobusTransfers(t *testing.T) {
 
 func TestGlobusFilesStaged(t *testing.T) {
 	assert := assert.New(t)
-	endpoint, _ := NewEndpoint("source")
+	endpoint, _ := NewEndpointFromConfig("source")
 
 	// provide an empty slice of filenames, which should return true
 	staged, err := endpoint.FilesStaged([]any{})
@@ -167,8 +167,8 @@ func destDirName(n int) string {
 
 func TestGlobusTransfer(t *testing.T) {
 	assert := assert.New(t)
-	source, _ := NewEndpoint("source")
-	destination, _ := NewEndpoint("destination")
+	source, _ := NewEndpointFromConfig("source")
+	destination, _ := NewEndpointFromConfig("destination")
 
 	fileXfers := make([]endpoints.FileTransfer, 0)
 	for i := 1; i <= 3; i++ {
@@ -210,7 +210,7 @@ func TestGlobusTransfer(t *testing.T) {
 
 func TestUnknownGlobusStatus(t *testing.T) {
 	assert := assert.New(t)
-	endpoint, _ := NewEndpoint("source")
+	endpoint, _ := NewEndpointFromConfig("source")
 
 	// make up a bogus transfer UUID and check its status
 	taskId := uuid.New()
@@ -221,8 +221,8 @@ func TestUnknownGlobusStatus(t *testing.T) {
 
 func TestGlobusTransferCancellation(t *testing.T) {
 	assert := assert.New(t)
-	source, _ := NewEndpoint("source")
-	destination, _ := NewEndpoint("destination")
+	source, _ := NewEndpointFromConfig("source")
+	destination, _ := NewEndpointFromConfig("destination")
 
 	fileXfers := make([]endpoints.FileTransfer, 0)
 	for i := 1; i <= 3; i++ {

--- a/endpoints/globus/endpoint_test.go
+++ b/endpoints/globus/endpoint_test.go
@@ -56,28 +56,25 @@ var sourceFilesById = map[string]string{
 }
 
 var globusConfig string = fmt.Sprintf(`
+credentials:
+  globus:
+    id: ${DTS_GLOBUS_CLIENT_ID}
+    secret: ${DTS_GLOBUS_CLIENT_SECRET}
 endpoints:
   source:
     name: %s
     id: %s
     provider: globus
-    auth:
-      client_id: ${DTS_GLOBUS_CLIENT_ID}
-      client_secret: ${DTS_GLOBUS_CLIENT_SECRET}
+    credential: globus
   destination:
     name: DTS Globus Test Endpoint
     id: ${DTS_GLOBUS_TEST_ENDPOINT}
     provider: globus
-    auth:
-      client_id: ${DTS_GLOBUS_CLIENT_ID}
-      client_secret: ${DTS_GLOBUS_CLIENT_SECRET}
+    credential: globus
   not-globus-jdp:
     name: lalala
     id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
     provider: not-globus
-    auth:
-      client_id: ${DTS_GLOBUS_CLIENT_ID}
-      client_secret: ${DTS_GLOBUS_CLIENT_SECRET}
 `, sourceEndpointName, sourceEndpointId)
 
 // this function gets called at the begіnning of a test session

--- a/endpoints/local/endpoint.go
+++ b/endpoints/local/endpoint.go
@@ -85,6 +85,10 @@ func (ep *Endpoint) setRoot(dir string) error {
 	return err
 }
 
+func (ep *Endpoint) Provider() string {
+	return "local"
+}
+
 func (ep *Endpoint) Root() string {
 	return ep.root
 }
@@ -175,9 +179,15 @@ func (ep *Endpoint) transferFiles(xferId uuid.UUID, dest endpoints.Endpoint) {
 
 func (ep *Endpoint) Transfer(dst endpoints.Endpoint, files []endpoints.FileTransfer) (uuid.UUID, error) {
 	var xferId uuid.UUID
+
 	_, ok := dst.(*Endpoint)
 	if !ok {
-		return xferId, fmt.Errorf("Cannot transfer files between a local endpoint and another type of endpoint!")
+		return xferId, &endpoints.IncompatibleDestinationError{
+			Source:              ep.Name,
+			SourceProvider:      "local",
+			Destination:         ep.Name,
+			DestinationProvider: ep.Provider(),
+		}
 	}
 
 	// first, we check that all requested files are staged on this endpoint

--- a/endpoints/local/endpoint_test.go
+++ b/endpoints/local/endpoint_test.go
@@ -92,7 +92,7 @@ func setup() {
 	// create source files
 	for i := 1; i <= 3; i++ {
 		err = os.WriteFile(filepath.Join(sourceRoot, fmt.Sprintf("file%d.txt", i)),
-			[]byte(fmt.Sprintf("This is the content of file %d.", i)), 0600)
+			fmt.Appendf(nil, "This is the content of file %d.", i), 0600)
 		if err != nil {
 			panic(err)
 		}
@@ -103,7 +103,7 @@ func setup() {
 	myConfig = strings.ReplaceAll(myConfig, "DESTINATION_ROOT", destinationRoot)
 	myConfig = strings.ReplaceAll(myConfig, "DESTINATION_CANCEL", destinationRootCancel)
 	fmt.Printf(myConfig)
-	err = config.InitSelected([]byte(myConfig), false, false, true)
+	err = config.InitSelected([]byte(myConfig), false, false, false, true)
 	if err != nil {
 		panic(err)
 	}

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -133,7 +133,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 6
-var patchVersion = 2
+var patchVersion = 3
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -133,7 +133,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 7
-var patchVersion = 0
+var patchVersion = 1
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -132,8 +132,8 @@ func (service *prototype) Close() {
 
 // Version numbers
 var majorVersion = 0
-var minorVersion = 6
-var patchVersion = 3
+var minorVersion = 7
+var patchVersion = 0
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -670,13 +670,9 @@ func (service *prototype) createTransfer(ctx context.Context,
 	}
 
 	// Check whether the destination is a "custom transfer", available only to Special People.
-	// Such a destination is encoded as "<provider>:<id>:<credential>", where
-	// * provider is the name of a tranport service (e.g. "globus") as in the config file
-	// * id is a corresponding identifier for the destination (e.g. a UUID for a Globus share)
-	// * credential is the name of a credential stored in the config file
 	if strings.Contains(input.Body.Destination, ":") {
-		terms := strings.Split(input.Body.Destination, ":")
-		if len(terms) != 3 {
+		_, err := endpoints.ParseCustomSpec(input.Body.Destination)
+		if err != nil {
 			return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid destination: %s", input.Body.Destination))
 		}
 		if !user.IsSuper { // not allowed to do custom transfers

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -138,12 +138,13 @@ var patchVersion = 1
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)
 
-// authorize clients for the DTS, returning information about the user
+// Authorize clients for the DTS, returning information about the user
 // corresponding to the token in the header (or an error describing any issue
-// encountered)
-func authorize(authorizationHeader string) (auth.Client, error) {
+// encountered). This returns either an auth.User (if authorized via the DTS Authenticator) or
+// an auth.Client (if authorized via the KBase auth2 server).
+func authorize(authorizationHeader string) (any, error) {
 	if !strings.Contains(authorizationHeader, "Bearer") {
-		return auth.Client{}, fmt.Errorf("Invalid authorization header")
+		return auth.User{}, fmt.Errorf("Invalid authorization header")
 	}
 	b64Token := authorizationHeader[len("Bearer "):]
 	accessTokenBytes, err := base64.StdEncoding.DecodeString(b64Token)
@@ -160,12 +161,7 @@ func authorize(authorizationHeader string) (auth.Client, error) {
 		var user auth.User
 		user, err = authenticator.GetUser(accessToken)
 		if err == nil {
-			client = auth.Client{
-				Name:         user.Name,
-				Email:        user.Email,
-				Orcid:        user.Orcid,
-				Organization: user.Organization,
-			}
+			return user, nil
 		}
 	}
 	if err != nil {
@@ -424,7 +420,7 @@ func searchDatabase(_ context.Context,
 	input *SearchDatabaseInput,
 	specific map[string]json.RawMessage) (*SearchResultsOutput, error) {
 
-	client, err := authorize(input.Authorization)
+	userOrClient, err := authorize(input.Authorization)
 	if err != nil {
 		return nil, err
 	}
@@ -475,10 +471,15 @@ func searchDatabase(_ context.Context,
 		}
 	}
 
-	// FIXME: for now, if a user ORCID is not specified, use the client's ORCID
+	// FIXME: for now, if a user ORCID is not specified, use the user/client's ORCID
 	orcid := input.Orcid
 	if orcid == "" {
-		orcid = client.Orcid
+		switch u := userOrClient.(type) {
+		case auth.User:
+			orcid = u.Orcid
+		case auth.Client:
+			orcid = u.Orcid
+		}
 	}
 
 	slog.Info(fmt.Sprintf("Searching database %s for files...", input.Database))
@@ -568,7 +569,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 		Limit         int    `json:"limit" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
 	}) (*FileMetadataOutput, error) {
 
-	client, err := authorize(input.Authorization)
+	userOrClient, err := authorize(input.Authorization)
 	if err != nil {
 		return nil, err
 	}
@@ -595,7 +596,12 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 	// FIXME: for now, if a user ORCID is not specified, use the client's ORCID
 	orcid := input.Orcid
 	if orcid == "" {
-		orcid = client.Orcid
+		switch u := userOrClient.(type) {
+		case auth.User:
+			orcid = u.Orcid
+		case auth.Client:
+			orcid = u.Orcid
+		}
 	}
 
 	descriptors, err := db.Descriptors(orcid, ids)
@@ -633,19 +639,50 @@ func (service *prototype) createTransfer(ctx context.Context,
 		ContentType   string          `header:"Content-Type" doc:"Content-Type header (must be application/json)"`
 	}) (*TransferOutput, error) {
 
-	_, err := authorize(input.Authorization)
+	userOrClient, err := authorize(input.Authorization)
 	if err != nil {
 		return nil, err
 	}
 
 	// fetch information about the requesting user
-	var user auth.User
+	user, isUser := userOrClient.(auth.User)
+	if !isUser {
+		client := userOrClient.(auth.Client)
+		user = auth.User{
+			Name:         client.Name,
+			Email:        client.Email,
+			Orcid:        client.Orcid,
+			Organization: client.Organization,
+		}
+	}
+
 	if input.Body.Orcid == "" {
 		return nil, huma.Error401Unauthorized("No user ORCID was provided")
 	}
-	// FIXME: we just extract the ORCID at the moment
-	// FIXME: we should get the other stuff from the ORCID public API
-	user.Orcid = input.Body.Orcid
+	if !isUser {
+		// Override the client's ORCID
+		user.Orcid = input.Body.Orcid
+	} else {
+		// a user is requesting a transfer on behalf of another user
+		// FIXME: for now, we only extract the ORCID and keep everything else the same, but at length
+		// FIXME: we should fill in the other fields with the ORCID public record
+		user.Orcid = input.Body.Orcid
+	}
+
+	// Check whether the destination is a "custom transfer", available only to Special People.
+	// Such a destination is encoded as "<provider>:<id>:<credential>", where
+	// * provider is the name of a tranport service (e.g. "globus") as in the config file
+	// * id is a corresponding identifier for the destination (e.g. a UUID for a Globus share)
+	// * credential is the name of a credential stored in the config file
+	if strings.Contains(input.Body.Destination, ":") {
+		terms := strings.Split(input.Body.Destination, ":")
+		if len(terms) != 3 {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid destination: %s", input.Body.Destination))
+		}
+		if !user.IsSuper { // not allowed to do custom transfers
+			return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid destination: %s", input.Body.Destination))
+		}
+	}
 
 	taskId, err := tasks.Create(tasks.Specification{
 		User:         user,

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -133,7 +133,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 6
-var patchVersion = 1
+var patchVersion = 2
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -529,7 +529,7 @@ func TestCreateTransfer(t *testing.T) {
 
 	status, err := queryTransfer()
 	assert.Nil(err)
-	assert.True(status.Status != "failed")
+	assert.NotEqual("failed", status.Status)
 
 	// wait a bit for the task to finish (shouldn't take long)
 	time.Sleep(600 * time.Millisecond)
@@ -537,7 +537,7 @@ func TestCreateTransfer(t *testing.T) {
 	// query the transfer again
 	status, err = queryTransfer()
 	assert.Nil(err)
-	assert.True(status.Status == "succeeded")
+	assert.Equal("succeeded", status.Status)
 
 	// check for the files in the payload
 	username := testUser
@@ -601,7 +601,7 @@ func TestCreateAndCancelTransfer(t *testing.T) {
 	// get the transfer status
 	status, err := queryTransfer()
 	assert.Nil(err)
-	assert.True(status.Status != "failed")
+	assert.NotEqual("failed", status.Status)
 
 	// cancel the transfer
 	err = cancelTransfer()

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -74,7 +74,7 @@ func Start() error {
 	if firstCall {
 		// NOTE: it's okay if these endpoint providers have already been registered,
 		// NOTE: as they can be used in testing
-		err := endpoints.RegisterEndpointProvider("globus", globus.NewEndpoint)
+		err := endpoints.RegisterEndpointProvider("globus", globus.NewEndpointFromConfig)
 		if err == nil {
 			err = endpoints.RegisterEndpointProvider("local", local.NewEndpoint)
 		}
@@ -361,7 +361,8 @@ func processTasks() {
 	deleteAfter := time.Duration(config.Service.DeleteAfter) * time.Second
 
 	// start scurrying around
-	for {
+	running := true
+	for running {
 		select {
 		case newTask := <-createTaskChan: // Create() called
 			newTask.Id = uuid.New()
@@ -435,7 +436,7 @@ func processTasks() {
 		case <-stopChan: // Stop() called
 			err := saveTasks(tasks, dataStore) // don't forget to save our state!
 			errorChan <- err
-			break
+			running = false
 		}
 	}
 }


### PR DESCRIPTION
For our GROW dataset transfer to Colorado State University, we need to specify a Globus destination endpoint that is not pre-configured. Here's how we've done it:

1. I added a "superuser" column to the encrypted DTS authentication file that, if set/checked/enabled allows a set of privileged operations for the corresponding authenticated user.
2. I added the ability to configure a Globus endpoint at runtime (plumbing, mostly).
3. I factored out a `credentials` section in the config file to gather named sets of credentials. This simplifies the specification of endpoints in the config, and also supports run-time-specified endpoints.
4. I added the first "off-menu" feature for super-users: the ability to specify a custom destination (see `endpoints/custom.go`) with a string of the form `"<provider>:<uuid>:<path>:<credential>".

Above, `<provider>` has to be `globus` for now, and `<uuid>` and `<path>` give the Globus share UUID and the path within that share to which files are written. The `<credential>` portion identifies the credential to use for the Globus transfer by its name in the config file.

This seems to work properly, and it's already deployed in Spin so I can use it for the CSU file transfer. But more testing is always good.