### PR TITLE
For some reason, some NMDC queries seem to take a long time.

### DIFF
--- a/databases/http.go
+++ b/databases/http.go
@@ -31,9 +31,9 @@ import (
 
 // Here's a secure HTTP client that can be used to connect to databases. It
 // sets a reasonable timeout and enables HTTP Strict Transport Security (HSTS).
-func SecureHttpClient() http.Client {
+func SecureHttpClient(timeout time.Duration) http.Client {
 	client := http.Client{
-		Timeout: time.Second * 10,
+		Timeout: timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Scheme == "http" {
 				return &DowngradedRedirectError{

--- a/databases/jdp/database.go
+++ b/databases/jdp/database.go
@@ -155,7 +155,7 @@ func (db *Database) Descriptors(orcid string, fileIds []string) ([]map[string]an
 	type MetadataRequest struct {
 		Ids                []string `json:"ids"`
 		Aggregations       bool     `json:"aggregations"`
-		IncludePrivateData int     `json:"include_private_data"`
+		IncludePrivateData int      `json:"include_private_data"`
 	}
 	data, err := json.Marshal(MetadataRequest{
 		Ids:                strippedFileIds,

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -96,7 +96,7 @@ func NewDatabase() (databases.Database, error) {
 
 	// NOTE: we prevent redirects from HTTPS -> HTTP!
 	db := &Database{
-		Client: databases.SecureHttpClient(),
+		Client: databases.SecureHttpClient(time.Second * 20),
 		EndpointForHost: map[string]string{
 			"https://data.microbiomedata.org/data/": nerscEndpoint,
 			"https://nmdcdemo.emsl.pnnl.gov/":       emslEndpoint,

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -61,7 +61,7 @@ func setup() {
 
 	// construct NMDC-specific search parameters for a study
 	nmdcSearchParams = make(map[string]any)
-	nmdcSearchParams["study_id"] = "nmdc:sty-11-5tgfr349"
+	nmdcSearchParams["study_id"] = "nmdc:sty-11-r2h77870"
 }
 
 // this function gets called after all tests have been run


### PR DESCRIPTION
This PR adds a timeout parameter to the secure HTTP client that allows NMDC tests to pass.