### PR TITLE
Idle Globus connections are now terminated before authentication.

### DIFF
--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -412,6 +412,7 @@ func (ep *Endpoint) authenticate() error {
 	req.Header.Add("Content-Type", "application-x-www-form-urlencoded")
 
 	// send the request
+	ep.Client.CloseIdleConnections()
 	resp, err := ep.Client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is my latest attempt to fix the marginally-reproducible Globus auth 500 error. The only thing I really know about it at this point is that it happens after long idle periods, so I've added a function call that closes idle connections right before attempting to (re-)authenticate.

This fix was deployed yesterday, and we won't know whether "it works" unless these errors stop occuring after idle periods. Let's see what happens over the next few days.