### PR TITLE
Added transfer ID to manifest (in `id` field).

### DIFF
--- a/services/prototype.go
+++ b/services/prototype.go
@@ -133,7 +133,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 9
-var patchVersion = 3
+var patchVersion = 4
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -359,6 +359,7 @@ func (task *transferTask) createManifest() (*datapackage.Package, error) {
 	}
 
 	taskUser := map[string]any{
+		"id":    task.Id.String(),
 		"title": task.User.Name,
 		"role":  "author",
 	}


### PR DESCRIPTION
We're just adding the transfer ID to the manifest for easier credit tracking. This change was deployed today.