### PR TITLE
Finally, a promising fix for the Globus authentication 500 error!

### DIFF
--- a/services/prototype.go
+++ b/services/prototype.go
@@ -133,7 +133,7 @@ func (service *prototype) Close() {
 // Version numbers
 var majorVersion = 0
 var minorVersion = 9
-var patchVersion = 4
+var patchVersion = 5
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)


### PR DESCRIPTION
This PR includes a couple of changes that seem to address the Globus auth error encountered when the DTS attempts to renew an expired token:

* The request parameter specifying the desired authentication scopes for the Globus client token could previously be sent without a value. This has now been fixed, and I believe it was the cause of the 500 error. I can report this to the Globus folks by reproducing the error using a request with a blank scopes parameter.
* A fresh HTTP client is used every time, to avoid spurious caching. I now believe this isn't strictly necessary, but it's a nice way to divorce the lifetime of the client from the Globus endpoint proxy.