### PR TITLE
Added a transfer record endpoint for querying the journal.

### DIFF
--- a/services/prototype.go
+++ b/services/prototype.go
@@ -819,7 +819,7 @@ func (service *prototype) getTransferRecords(ctx context.Context,
 	input *struct {
 		Authorization string    `header:"authorization" doc:"Authorization header with encoded access token"`
 		Start         time.Time `path:"start" example:"2025-01-02T15:04:05Z07:00" doc:"the start date for the requested transfers"`
-		End           time.Time `path:"end" example:"2025-02-01T11:00:00Z07:00" doc:"the start date for the requested transfers"`
+		End           time.Time `path:"end" example:"2025-02-01T11:00:00Z07:00" doc:"the end date for the requested transfers"`
 	}) (*TransferRecordsOutput, error) {
 
 	_, err := authorize(input.Authorization)


### PR DESCRIPTION
This PR adds a `transfer/records` endpoint that allows for the querying of completed transfers bookended by two timestamps. The logic is simple, but devising a test for it can take some care.

In advance of devising a unit test for this endpoing (in part because we're reworking a lot of unit tests at the moment), I wanted to put this up and try to test it this weekend when I'm testing the new transfer orchestration code in NERSC's Spin environment.