### PR TITLE
Add permissions section to format action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run formatting
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
This PR attempts to address the security warning about a missing permissions section in the format action.