### PR TITLE
Fixing issues related to NMDC studies and data objects

### DIFF
--- a/.github/workflows/autotest_prs.yml
+++ b/.github/workflows/autotest_prs.yml
@@ -63,7 +63,7 @@ jobs:
         DTS_NMDC_PASSWORD: ${{ secrets.DTS_NMDC_PASSWORD }}
       run: |
         PACKAGES=$(go list ./... | grep -v /integration)
-        go test -v $PACKAGES -coverprofile=coverage.out -covermode=atomic
+        go test $PACKAGES -coverprofile=coverage.out -covermode=atomic
 
     - name: Testing DTS against mock services
       id: test-mock
@@ -71,7 +71,7 @@ jobs:
       env:
         DTS_TEST_WITH_MOCK_SERVICES: true
       run: |
-        go test -v ./... -coverprofile=coverage_mock.out -covermode=atomic
+        go test ./... -coverprofile=coverage_mock.out -covermode=atomic
 
     - name: Run AWS example script # example script for using the aws go sdk
       shell: bash

--- a/databases/errors.go
+++ b/databases/errors.go
@@ -68,6 +68,16 @@ func (e UnavailableError) Error() string {
 }
 
 // This error type is returned when an invalid database-specific search
+// query is specified
+type InvalidSearchQuery struct {
+	Database, Message string
+}
+
+func (e InvalidSearchQuery) Error() string {
+	return fmt.Sprintf("Invalid search query for database '%s': %s", e.Database, e.Message)
+}
+
+// This error type is returned when an invalid database-specific search
 // parameter is specified
 type InvalidSearchParameter struct {
 	Database, Message string
@@ -116,6 +126,16 @@ type PermissionDeniedError struct {
 func (e PermissionDeniedError) Error() string {
 	return fmt.Sprintf("Can't access resource '%s' in database '%s': permission denied",
 		e.ResourceId, e.Database)
+}
+
+// this error type is returned when an invalid resource identifier is encountered
+type InvalidResourceIdError struct {
+	Database   string
+	ResourceId string
+}
+
+func (e InvalidResourceIdError) Error() string {
+	return fmt.Sprintf("Invalid resource for database '%s': %s", e.Database, e.ResourceId)
 }
 
 // this error type is returned when one or more resources are requested and is not found

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -202,12 +202,9 @@ func (db Database) Descriptors(orcid string, fileIds []string) ([]map[string]any
 	}
 
 	// fetch metadata by study
-
 	dataObjectIdsByStudy := make(map[string][]string)
 	for i, studyId := range studyIds {
-		if _, found := dataObjectIdsByStudy[studyId]; !found {
-			dataObjectIdsByStudy[studyId] = append(dataObjectIdsByStudy[studyId], dataObjectIds[i])
-		}
+		dataObjectIdsByStudy[studyId] = append(dataObjectIdsByStudy[studyId], dataObjectIds[i])
 	}
 
 	var descriptors []map[string]any

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -594,6 +594,9 @@ func (db Database) dataObjects(params url.Values) ([]DataObject, error) {
 // returns descriptors for all data objects for a given study
 func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[string]any, error) {
 	relatedCredit, err := db.creditMetadataForStudy(studyId)
+	if err != nil {
+		return nil, err
+	}
 
 	// fetch the data objects for the study
 	resource := fmt.Sprintf("data_objects/study/%s", studyId)
@@ -619,12 +622,6 @@ func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[st
 		}
 	}
 	return descriptors, nil
-}
-
-func ѕtudyIdFromFileId(fileId string) string {
-	// the file ID is <nmdc-study-id>:<nmdc-dataobject-id-without-nmdc-prefix>
-	lastColon := strings.LastIndex(fileId, ":") // we assume lastColon != -1
-	return fileId[:lastColon]
 }
 
 // returns a descriptor for the given data object, including the given credit

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -624,7 +624,7 @@ func (db Database) createDataObjectDescriptor(dataObject DataObject, studyCredit
 		"description": dataObject.Description,
 		"format":      formatFromType(dataObject.Type),
 		"hash":        dataObject.MD5Checksum,
-		"id":          dataObject.StudyId + strings.ReplaceAll(dataObject.Id, "nmdc:", ""),
+		"id":          dataObject.StudyId + strings.ReplaceAll(dataObject.Id, "nmdc:", ":"),
 		"mediatype":   mimetypeForFile(dataObject.URL),
 		"name":        dataResourceName(dataObject.Name),
 		"path":        dataObject.URL,

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -588,14 +588,18 @@ func (db Database) createDataObjectAndBiosampleDescriptors(dataObjects []DataObj
 	// create data object descriptors and fill in metadata
 	dataObjectDescriptors := make([]map[string]any, len(dataObjects))
 	creditForWorkflow := make(map[string]credit.CreditMetadata)
-	biosampleForWorkflow := make(map[string]any)
+	biosamplesForWorkflow := make(map[string][]any)
 	for i, dataObject := range dataObjects {
 		workflowId := dataObject.WasGeneratedBy
 		if _, found := creditForWorkflow[workflowId]; !found {
 			var err error
-			creditForWorkflow[workflowId], biosampleForWorkflow[workflowId], err = db.creditAndBiosampleForWorkflow(workflowId)
+			var biosamples []map[string]any
+			creditForWorkflow[workflowId], biosamples, err = db.creditAndBiosamplesForWorkflow(workflowId)
 			if err != nil {
 				return nil, nil, err
+			}
+			for biosample := range biosamples {
+				biosamplesForWorkflow[workflowId] = append(biosamplesForWorkflow[workflowId], biosample)
 			}
 		}
 		dataObjectDescriptors[i] = db.createDataObjectDescriptor(dataObject, creditForWorkflow[workflowId])
@@ -603,29 +607,31 @@ func (db Database) createDataObjectAndBiosampleDescriptors(dataObjects []DataObj
 
 	// create biosample descriptors
 	biosampleDescriptors := make([]map[string]any, 0)
-	for _, b := range biosampleForWorkflow {
-		biosample := b.(map[string]any)
-		var studyIds []string
-		switch s := biosample["associated_studies"].(type) {
-		case string:
-			studyIds = []string{s}
-		case []any:
-			for _, si := range s {
-				studyId, ok := si.(string)
-				if ok {
-					studyIds = append(studyIds, studyId)
+	for _, samples := range biosamplesForWorkflow {
+		for _, sample := range samples {
+			biosample := sample.(map[string]any)
+			var studyIds []string
+			switch s := biosample["associated_studies"].(type) {
+			case string:
+				studyIds = []string{s}
+			case []any:
+				for _, si := range s {
+					studyId, ok := si.(string)
+					if ok {
+						studyIds = append(studyIds, studyId)
+					}
 				}
+			default: // nil, for example
 			}
-		default: // nil, for example
-		}
-		for _, studyId := range studyIds {
-			if biosample["associated_studies"] != nil {
-				descriptor := map[string]any{
-					"name":  fmt.Sprintf("biosample-metadata-for-study-%s", studyId),
-					"title": fmt.Sprintf("NMDC biosample metadata for study %s", studyId),
-					"data":  biosample,
+			for _, studyId := range studyIds {
+				if biosample["associated_studies"] != nil {
+					descriptor := map[string]any{
+						"name":  fmt.Sprintf("biosample-metadata-for-study-%s", studyId),
+						"title": fmt.Sprintf("NMDC biosample metadata for study %s", studyId),
+						"data":  biosample,
+					}
+					biosampleDescriptors = append(biosampleDescriptors, descriptor)
 				}
-				biosampleDescriptors = append(biosampleDescriptors, descriptor)
 			}
 		}
 	}
@@ -675,12 +681,12 @@ func (db Database) createDataObjectDescriptor(dataObject DataObject, studyCredit
 
 // fetch credit and biosample metadata related to the given workflow execution ID
 // if the workflow id is empty, of unknown format, or associated with raw data, we return empty metadata to allow the transfer to proceed
-func (db *Database) creditAndBiosampleForWorkflow(workflowExecId string) (credit.CreditMetadata, map[string]any, error) {
+func (db *Database) creditAndBiosamplesForWorkflow(workflowExecId string) (credit.CreditMetadata, []map[string]any, error) {
 	var relatedCredit credit.CreditMetadata
-	var relatedBiosample map[string]any // pure-JSON representation
+	var relatedBiosamples []map[string]any // pure-JSON representation
 
 	if workflowExecId == "" {
-		return relatedCredit, relatedBiosample, nil
+		return relatedCredit, relatedBiosamples, nil
 	}
 
 	if strings.Contains(workflowExecId, "nmdc:wf") {
@@ -709,22 +715,16 @@ func (db *Database) creditAndBiosampleForWorkflow(workflowExecId string) (credit
 		}
 
 		// biosample metadata
-		if len(workflowExec.Biosamples) == 1 {
-			relatedBiosample = workflowExec.Biosamples[0].(map[string]any)
-		} else if len(workflowExec.Biosamples) > 1 {
-			return credit.CreditMetadata{}, nil, &TooManyRecordsError{
-				Identifier:   workflowExecId,
-				ResourceType: "biosamples",
-				Count:        len(workflowExec.Biosamples),
-			}
+		for _, biosample := range workflowExec.Biosamples {
+			relatedBiosamples = append(relatedBiosamples, biosample.(map[string]any))
 		}
 
-		return relatedCredit, relatedBiosample, nil
+		return relatedCredit, relatedBiosamples, nil
 	} else if strings.Contains(workflowExecId, "nmdc:om") {
 		// data object is raw data; we don't fetch such metadata
-		return relatedCredit, relatedBiosample, nil
+		return relatedCredit, relatedBiosamples, nil
 	}
-	return relatedCredit, relatedBiosample, nil
+	return relatedCredit, relatedBiosamples, nil
 }
 
 var idCategoryLabels = map[string]string{

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -602,6 +602,7 @@ func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[st
 
 // returns a descriptor for the given data object, including the given credit
 // metadata (mined from the study to which the data object belongs)
+// NOTE: the ѕtudy to which the data object belongs іs identified in its StudyId field
 func (db Database) createDataObjectDescriptor(dataObject DataObject, studyCredit credit.CreditMetadata) map[string]any {
 	// fill in some particulars
 	objectCredit := studyCredit

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -598,7 +598,7 @@ func (db Database) createDataObjectAndBiosampleDescriptors(dataObjects []DataObj
 			if err != nil {
 				return nil, nil, err
 			}
-			for biosample := range biosamples {
+			for _, biosample := range biosamples {
 				biosamplesForWorkflow[workflowId] = append(biosamplesForWorkflow[workflowId], biosample)
 			}
 		}

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -101,14 +101,13 @@ func NewDatabase(conf Config) (databases.Database, error) {
 
 	// fetch functional endpoint names and map URLs to them
 	// (see https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/globus.html)
-	// NOTE: we prevent redirects from HTTPS -> HTTP!
 	baseUrl := defaultBaseApiURL
 	if conf.BaseURL != "" {
 		baseUrl = conf.BaseURL
 	}
 	db := &Database{
 		BaseURL: baseUrl,
-		Client:  databases.SecureHttpClient(time.Second * 120),
+		Client:  databases.SecureHttpClient(time.Second * 120), // prevent HTTPS -> HTTP redirect!
 		EndpointForHost: map[string]string{
 			"https://data.microbiomedata.org/data/": conf.Endpoints.Nersc,
 			"https://nmdcdemo.emsl.pnnl.gov/":       conf.Endpoints.Emsl,
@@ -145,7 +144,6 @@ func (db Database) SpecificSearchParameters() map[string]any {
 		"filter":         "",
 		"sort":           "",
 		"sample_id":      "",
-		"study_id":       "",
 		"extra":          []string{},
 	}
 }
@@ -171,22 +169,22 @@ func (db *Database) Search(orcid string, params databases.SearchParameters) (dat
 	}
 
 	// NOTE: NMDC doesn't do "search" at the moment, so we interpret a query as
-	// NOTE: a filter
-	if params.Query != "" {
-		p.Add("filter", params.Query)
-	}
-
-	var descriptors []map[string]any
-	var err error
-	if p.Has("study_id") { // fetch data objects associated with this study
-		descriptors, err = db.createDataObjectDescriptorsForStudy(p.Get("study_id"))
-	} else {
-		var dataObjects []DataObject
-		dataObjects, err = db.dataObjects(p)
-		if err != nil {
-			return databases.SearchResults{}, err
+	// NOTE: the study with which desired data objects are associated
+	if params.Query == "" {
+		return databases.SearchResults{}, &databases.InvalidSearchQuery{
+			Database: "nmdc",
+			Message:  "no query provided",
 		}
-		descriptors, _, err = db.createDataObjectAndBiosampleDescriptors(dataObjects)
+	} else if !isValidStudyId(params.Query) {
+		return databases.SearchResults{}, &databases.InvalidSearchQuery{
+			Database: "nmdc",
+			Message:  fmt.Sprintf("invalid study ID: %s", params.Query),
+		}
+	}
+	studyId := params.Query
+	descriptors, err := db.createDataObjectDescriptorsForStudy(studyId)
+	if err != nil {
+		return databases.SearchResults{}, err
 	}
 	return databases.SearchResults{
 		Descriptors: descriptors,
@@ -198,59 +196,81 @@ func (db Database) Descriptors(orcid string, fileIds []string) ([]map[string]any
 		return nil, err
 	}
 
-	// fetch data objects in batches using MongoDB $in filter via nmdcschema endpoint
-	const batchSize = 200
-	dataObjects := make([]DataObject, 0, len(fileIds))
-	for start := 0; start < len(fileIds); start += batchSize {
-		end := start + batchSize
-		if end > len(fileIds) {
-			end = len(fileIds)
-		}
-		batch := fileIds[start:end]
-
-		idsJSON, err := json.Marshal(batch)
-		if err != nil {
-			return nil, err
-		}
-		filter := fmt.Sprintf(`{"id":{"$in":%s}}`, string(idsJSON))
-
-		// paginate through results for this batch
-		pageToken := ""
-		for {
-			params := url.Values{}
-			params.Set("filter", filter)
-			params.Set("max_page_size", strconv.Itoa(batchSize))
-			if pageToken != "" {
-				params.Set("page_token", pageToken)
-			}
-
-			body, err := db.get("nmdcschema/data_object_set", params)
-			if err != nil {
-				return nil, err
-			}
-
-			var result struct {
-				Resources     []DataObject `json:"resources"`
-				NextPageToken *string      `json:"next_page_token"`
-			}
-			if err := json.Unmarshal(body, &result); err != nil {
-				return nil, err
-			}
-			dataObjects = append(dataObjects, result.Resources...)
-
-			if result.NextPageToken == nil || *result.NextPageToken == "" {
-				break
-			}
-			pageToken = *result.NextPageToken
-		}
-	}
-
-	// fetch metadata for data objects and biosamples and turn them into descriptors
-	dataObjectDescriptors, biosampleDescriptors, err := db.createDataObjectAndBiosampleDescriptors(dataObjects)
+	studyIds, dataObjectIds, err := parseFileIds(fileIds)
 	if err != nil {
 		return nil, err
 	}
-	return slices.Concat(dataObjectDescriptors, biosampleDescriptors), nil
+
+	// fetch metadata by study
+
+	dataObjectIdsByStudy := make(map[string][]string)
+	for i, studyId := range studyIds {
+		if _, found := dataObjectIdsByStudy[studyId]; !found {
+			dataObjectIdsByStudy[studyId] = append(dataObjectIdsByStudy[studyId], dataObjectIds[i])
+		}
+	}
+
+	var descriptors []map[string]any
+	for studyId, dataObjectIds := range dataObjectIdsByStudy {
+		// fetch data objects in batches using MongoDB $in filter via nmdcschema endpoint
+		const batchSize = 200
+		dataObjects := make([]DataObject, 0, len(dataObjectIds))
+		for start := 0; start < len(dataObjectIds); start += batchSize {
+			end := start + batchSize
+			if end > len(dataObjectIds) {
+				end = len(dataObjectIds)
+			}
+			batch := dataObjectIds[start:end]
+
+			idsJSON, err := json.Marshal(batch)
+			if err != nil {
+				return nil, err
+			}
+			filter := fmt.Sprintf(`{"id":{"$in":%s}}`, string(idsJSON))
+
+			// paginate through results for this batch
+			pageToken := ""
+			for {
+				params := url.Values{}
+				params.Set("filter", filter)
+				params.Set("max_page_size", strconv.Itoa(batchSize))
+				if pageToken != "" {
+					params.Set("page_token", pageToken)
+				}
+
+				body, err := db.get("nmdcschema/data_object_set", params)
+				if err != nil {
+					return nil, err
+				}
+
+				var result struct {
+					Resources     []DataObject `json:"resources"`
+					NextPageToken *string      `json:"next_page_token"`
+				}
+				if err := json.Unmarshal(body, &result); err != nil {
+					return nil, err
+				}
+				dataObjects = append(dataObjects, result.Resources...)
+
+				if result.NextPageToken == nil || *result.NextPageToken == "" {
+					break
+				}
+				pageToken = *result.NextPageToken
+			}
+		}
+
+		// fetch credit metadata associated with the study
+		credit, err := db.creditMetadataForStudy(studyId)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, dataObject := range dataObjects {
+			descriptors = append(descriptors, db.createDataObjectDescriptor(dataObject, credit))
+		}
+	}
+
+	return descriptors, nil
 }
 
 func (db Database) EndpointNames() []string {
@@ -309,6 +329,36 @@ const (
 	defaultBaseApiURL  = "https://api.microbiomedata.org/"           // mongoDB
 	defaultBaseDataURL = "https://data-dev.microbiomedata.org/data/" // postgres (use in future)
 )
+
+func isValidStudyId(s string) bool {
+	return strings.HasPrefix(s, "nmdc:") && len(s) >= 6
+}
+
+func isValidDataObjectId(s string) bool {
+	return strings.HasPrefix(s, "nmdc:") && len(s) >= 6
+}
+
+func isValidFileId(s string) bool {
+	lastColon := strings.LastIndex(s, ":")
+	return lastColon != -1 && isValidStudyId(s[:lastColon]) && isValidDataObjectId("nmdc"+s[lastColon:])
+}
+
+func parseFileIds(fileIds []string) (studyIds, dataObjectIds []string, err error) {
+	studyIds = make([]string, len(fileIds))
+	dataObjectIds = make([]string, len(fileIds))
+	for i, fileId := range fileIds {
+		if !isValidFileId(fileId) {
+			err = &databases.InvalidResourceIdError{
+				Database:   "nmdc",
+				ResourceId: fileId,
+			}
+		}
+		lastColon := strings.LastIndex(fileId, ":")
+		studyIds[i] = fileId[:lastColon]
+		dataObjectIds[i] = "nmdc" + fileId[lastColon:]
+	}
+	return
+}
 
 //------------------------------
 // Access to NMDC API endpoints
@@ -541,24 +591,13 @@ func (db Database) dataObjects(params url.Values) ([]DataObject, error) {
 	return dataObjectResults.Results, err
 }
 
-// returns descriptors for data objects for a given study
+// returns descriptors for all data objects for a given study
 func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[string]any, error) {
-	// fetch the study and its metadata
-	resource := fmt.Sprintf("studies/%s", studyId)
-	body, err := db.get(resource, url.Values{})
-	if err != nil {
-		return nil, err
-	}
-	var study Study
-	err = json.Unmarshal(body, &study)
-	if err != nil {
-		return nil, err
-	}
-	relatedCredit := db.creditMetadataForStudy(study)
+	relatedCredit, err := db.creditMetadataForStudy(studyId)
 
 	// fetch the data objects for the study
-	resource = fmt.Sprintf("data_objects/study/%s", studyId)
-	body, err = db.get(resource, url.Values{})
+	resource := fmt.Sprintf("data_objects/study/%s", studyId)
+	body, err := db.get(resource, url.Values{})
 	if err != nil {
 		return nil, err
 	}
@@ -582,70 +621,10 @@ func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[st
 	return descriptors, nil
 }
 
-// returns descriptors for data objects and related biosample metadata
-// using workflow execution IDs (can be expensive)
-func (db Database) createDataObjectAndBiosampleDescriptors(dataObjects []DataObject) ([]map[string]any, []map[string]any, error) {
-	// assemble a set of workflows related to data objects
-	workflows := make(map[string]bool)
-	for _, dataObject := range dataObjects {
-		workflows[dataObject.WasGeneratedBy] = true
-	}
-
-	// fetch biosamples and credit metadata associated with workflows
-	creditForWorkflow := make(map[string]credit.CreditMetadata)
-	biosamplesForWorkflow := make(map[string][]any)
-	for workflowId := range workflows {
-		if _, found := creditForWorkflow[workflowId]; !found {
-			var err error
-			var biosamples []map[string]any
-			creditForWorkflow[workflowId], biosamples, err = db.creditAndBiosamplesForWorkflow(workflowId)
-			if err != nil {
-				return nil, nil, err
-			}
-			for _, biosample := range biosamples {
-				biosamplesForWorkflow[workflowId] = append(biosamplesForWorkflow[workflowId], biosample)
-			}
-		}
-	}
-
-	// create data object descriptors and fill in metadata
-	dataObjectDescriptors := make([]map[string]any, len(dataObjects))
-	for i, dataObject := range dataObjects {
-		dataObjectDescriptors[i] = db.createDataObjectDescriptor(dataObject, creditForWorkflow[dataObject.WasGeneratedBy])
-	}
-
-	// create biosample descriptors
-	biosampleDescriptors := make([]map[string]any, 0)
-	for _, samples := range biosamplesForWorkflow {
-		for _, sample := range samples {
-			biosample := sample.(map[string]any)
-			var studyIds []string
-			switch s := biosample["associated_studies"].(type) {
-			case string:
-				studyIds = []string{s}
-			case []any:
-				for _, si := range s {
-					studyId, ok := si.(string)
-					if ok {
-						studyIds = append(studyIds, studyId)
-					}
-				}
-			default: // nil, for example
-			}
-			for _, studyId := range studyIds {
-				if biosample["associated_studies"] != nil {
-					descriptor := map[string]any{
-						"name":  fmt.Sprintf("biosample-metadata-for-study-%s", studyId),
-						"title": fmt.Sprintf("NMDC biosample metadata for study %s", studyId),
-						"data":  biosample,
-					}
-					biosampleDescriptors = append(biosampleDescriptors, descriptor)
-				}
-			}
-		}
-	}
-
-	return dataObjectDescriptors, biosampleDescriptors, nil
+func ѕtudyIdFromFileId(fileId string) string {
+	// the file ID is <nmdc-study-id>:<nmdc-dataobject-id-without-nmdc-prefix>
+	lastColon := strings.LastIndex(fileId, ":") // we assume lastColon != -1
+	return fileId[:lastColon]
 }
 
 // returns a descriptor for the given data object, including the given credit
@@ -678,62 +657,14 @@ func (db Database) createDataObjectDescriptor(dataObject DataObject, studyCredit
 	// strip the host from the resource's path and assign it an endpoint
 	for hostURL, endpoint := range db.EndpointForHost {
 		if strings.Contains(descriptor["path"].(string), hostURL) {
-			path := strings.Replace(descriptor["path"].(string), hostURL, "", 1)
-			// URL-encode the path to prevent "nmdc:" from being interpreted as a URL protocol
-			descriptor["path"] = url.QueryEscape(path)
+			// scrub the host URL and escape the colon so it passes Frictionless validation
+			descriptor["path"] = strings.Replace(descriptor["path"].(string), hostURL, "", 1)
+			descriptor["path"] = strings.ReplaceAll(descriptor["path"].(string), ":", "\\:")
 			descriptor["endpoint"] = endpoint
 		}
 	}
 
 	return descriptor
-}
-
-// fetch credit and biosample metadata related to the given workflow execution ID
-// if the workflow id is empty, of unknown format, or associated with raw data, we return empty metadata to allow the transfer to proceed
-func (db *Database) creditAndBiosamplesForWorkflow(workflowExecId string) (credit.CreditMetadata, []map[string]any, error) {
-	var relatedCredit credit.CreditMetadata
-	var relatedBiosamples []map[string]any // pure-JSON representation
-
-	if workflowExecId == "" {
-		return relatedCredit, relatedBiosamples, nil
-	}
-
-	if strings.Contains(workflowExecId, "nmdc:wf") {
-		// data object is an analysis product; workflow execution has metadata
-
-		resource := fmt.Sprintf("workflow_executions/%s/related_resources", workflowExecId)
-		body, err := db.get(resource, url.Values{})
-		if err != nil {
-			return credit.CreditMetadata{}, nil, err
-		}
-		var workflowExec WorkflowExecution
-		err = json.Unmarshal(body, &workflowExec)
-		if err != nil {
-			return credit.CreditMetadata{}, nil, err
-		}
-
-		// credit metadata
-		if len(workflowExec.Studies) == 1 {
-			relatedCredit = db.creditMetadataForStudy(workflowExec.Studies[0])
-		} else if len(workflowExec.Studies) > 1 {
-			return credit.CreditMetadata{}, nil, &TooManyRecordsError{
-				Identifier:   workflowExecId,
-				ResourceType: "studies",
-				Count:        len(workflowExec.Studies),
-			}
-		}
-
-		// biosample metadata
-		for _, biosample := range workflowExec.Biosamples {
-			relatedBiosamples = append(relatedBiosamples, biosample.(map[string]any))
-		}
-
-		return relatedCredit, relatedBiosamples, nil
-	} else if strings.Contains(workflowExecId, "nmdc:om") {
-		// data object is raw data; we don't fetch such metadata
-		return relatedCredit, relatedBiosamples, nil
-	}
-	return relatedCredit, relatedBiosamples, nil
 }
 
 var idCategoryLabels = map[string]string{
@@ -744,7 +675,19 @@ var idCategoryLabels = map[string]string{
 }
 
 // extracts credit metadata from the given study
-func (db Database) creditMetadataForStudy(study Study) credit.CreditMetadata {
+func (db Database) creditMetadataForStudy(studyId string) (credit.CreditMetadata, error) {
+	// fetch the study and its metadata
+	resource := fmt.Sprintf("studies/%s", studyId)
+	body, err := db.get(resource, url.Values{})
+	if err != nil {
+		return credit.CreditMetadata{}, err
+	}
+	var study Study
+	err = json.Unmarshal(body, &study)
+	if err != nil {
+		return credit.CreditMetadata{}, err
+	}
+
 	// NOTE: principal investigator role is included with credit associations
 	contributors := make([]credit.Contributor, len(study.CreditAssociations))
 	for i, association := range study.CreditAssociations {
@@ -806,7 +749,7 @@ func (db Database) creditMetadataForStudy(study Study) credit.CreditMetadata {
 		RelatedIdentifiers: relatedIdentifiers,
 		ResourceType:       "dataset",
 		Titles:             titles,
-	}
+	}, nil
 }
 
 // returns the page number and page size corresponding to the given Pagination
@@ -938,13 +881,12 @@ func (db Database) addSpecificSearchParameters(params map[string]any, p *url.Val
 	for name, jsonValue := range params {
 		var ok bool
 		switch name {
-		case "activity_id", "data_object_id", "filter", "sort", "sample_id",
-			"study_id":
+		case "activity_id", "data_object_id", "filter", "sort", "sample_id":
 			var value string
 			if value, ok = jsonValue.(string); !ok {
 				return &databases.InvalidSearchParameter{
 					Database: "nmdc",
-					Message:  fmt.Sprintf("Invalid value for parameter %s (must be string)", name),
+					Message:  fmt.Sprintf("invalid value for parameter %s (must be string)", name),
 				}
 			}
 			p.Add(name, value)
@@ -953,7 +895,7 @@ func (db Database) addSpecificSearchParameters(params map[string]any, p *url.Val
 			if value, ok = jsonValue.(string); !ok {
 				return &databases.InvalidSearchParameter{
 					Database: "nmdc",
-					Message:  "Invalid NMDC requested extra field given (must be comma-delimited string)",
+					Message:  "invalid NMDC requested extra field given (must be comma-delimited string)",
 				}
 			}
 			acceptedValues := paramSpec["extra"].([]string)
@@ -965,7 +907,7 @@ func (db Database) addSpecificSearchParameters(params map[string]any, p *url.Val
 				} else {
 					return &databases.InvalidSearchParameter{
 						Database: "nmdc",
-						Message:  fmt.Sprintf("Invalid requested extra field: %s", fieldValue),
+						Message:  fmt.Sprintf("invalid requested extra field: %s", fieldValue),
 					}
 				}
 			}
@@ -974,7 +916,7 @@ func (db Database) addSpecificSearchParameters(params map[string]any, p *url.Val
 			if value, ok = jsonValue.(string); !ok {
 				return &databases.InvalidSearchParameter{
 					Database: "nmdc",
-					Message:  "Invalid NMDC requested extra field given (must be comma-delimited string)",
+					Message:  "invalid NMDC requested extra field given (must be comma-delimited string)",
 				}
 			}
 			acceptedValues := paramSpec["extra"].([]string)

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -266,6 +266,7 @@ func (db Database) Descriptors(orcid string, fileIds []string) ([]map[string]any
 		}
 
 		for _, dataObject := range dataObjects {
+			dataObject.StudyId = studyId
 			descriptors = append(descriptors, db.createDataObjectDescriptor(dataObject, credit))
 		}
 	}
@@ -518,6 +519,7 @@ type DataObject struct {
 	Id                     string   `json:"id"`
 	Name                   string   `json:"name"`
 	Description            string   `json:"description"`
+	StudyId                string   `json:"study_id,omitempty"`
 	WasGeneratedBy         string   `json:"was_generated_by,omitempty"`
 	AlternativeIdentifiers []string `json:"alternative_identifiers,omitempty"`
 }
@@ -567,30 +569,6 @@ type WorkflowExecution struct {
 	Biosamples []any   `json:"biosamples"`
 }
 
-// fetches metadata for data objects based on the given URL search parameters
-func (db Database) dataObjects(params url.Values) ([]DataObject, error) {
-	// extract any requested "extra" metadata fields (and scrub them from params)
-	if params.Has("extra") {
-		// currently no extra fields are supported
-		return nil, &ExtraFieldsInSearchError{
-			StudyID: params.Get("study_id"),
-			Fields:  strings.Split(params.Get("extra"), ","),
-		}
-	}
-
-	body, err := db.get("data_objects/", params)
-	type DataObjectResults struct {
-		// NOTE: we only extract the results field for now
-		Results []DataObject `json:"results"`
-	}
-	if err != nil {
-		return nil, err
-	}
-	var dataObjectResults DataObjectResults
-	err = json.Unmarshal(body, &dataObjectResults)
-	return dataObjectResults.Results, err
-}
-
 // returns descriptors for all data objects for a given study
 func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[string]any, error) {
 	relatedCredit, err := db.creditMetadataForStudy(studyId)
@@ -618,6 +596,7 @@ func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[st
 	descriptors := make([]map[string]any, 0)
 	for _, objectSet := range objectSets {
 		for _, dataObject := range objectSet.DataObjects {
+			dataObject.StudyId = studyId
 			descriptors = append(descriptors, db.createDataObjectDescriptor(dataObject, relatedCredit))
 		}
 	}
@@ -645,7 +624,7 @@ func (db Database) createDataObjectDescriptor(dataObject DataObject, studyCredit
 		"description": dataObject.Description,
 		"format":      formatFromType(dataObject.Type),
 		"hash":        dataObject.MD5Checksum,
-		"id":          dataObject.Id,
+		"id":          dataObject.StudyId + strings.ReplaceAll(dataObject.Id, "nmdc:", ""),
 		"mediatype":   mimetypeForFile(dataObject.URL),
 		"name":        dataResourceName(dataObject.Name),
 		"path":        dataObject.URL,

--- a/databases/nmdc/database.go
+++ b/databases/nmdc/database.go
@@ -585,12 +585,16 @@ func (db Database) createDataObjectDescriptorsForStudy(studyId string) ([]map[st
 // returns descriptors for data objects and related biosample metadata
 // using workflow execution IDs (can be expensive)
 func (db Database) createDataObjectAndBiosampleDescriptors(dataObjects []DataObject) ([]map[string]any, []map[string]any, error) {
-	// create data object descriptors and fill in metadata
-	dataObjectDescriptors := make([]map[string]any, len(dataObjects))
+	// assemble a set of workflows related to data objects
+	workflows := make(map[string]bool)
+	for _, dataObject := range dataObjects {
+		workflows[dataObject.WasGeneratedBy] = true
+	}
+
+	// fetch biosamples and credit metadata associated with workflows
 	creditForWorkflow := make(map[string]credit.CreditMetadata)
 	biosamplesForWorkflow := make(map[string][]any)
-	for i, dataObject := range dataObjects {
-		workflowId := dataObject.WasGeneratedBy
+	for workflowId := range workflows {
 		if _, found := creditForWorkflow[workflowId]; !found {
 			var err error
 			var biosamples []map[string]any
@@ -602,7 +606,12 @@ func (db Database) createDataObjectAndBiosampleDescriptors(dataObjects []DataObj
 				biosamplesForWorkflow[workflowId] = append(biosamplesForWorkflow[workflowId], biosample)
 			}
 		}
-		dataObjectDescriptors[i] = db.createDataObjectDescriptor(dataObject, creditForWorkflow[workflowId])
+	}
+
+	// create data object descriptors and fill in metadata
+	dataObjectDescriptors := make([]map[string]any, len(dataObjects))
+	for i, dataObject := range dataObjects {
+		dataObjectDescriptors[i] = db.createDataObjectDescriptor(dataObject, creditForWorkflow[dataObject.WasGeneratedBy])
 	}
 
 	// create biosample descriptors

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -801,7 +801,7 @@ func TestDescriptors(t *testing.T) {
 		}
 	}
 	assert.Nil(err, "NMDC resource query encountered an error")
-	assert.True(len(descriptors) >= expectedCount, // can include biosample metadata!
+	assert.Equal(len(descriptors), expectedCount, // can include biosample metadata!
 		"NMDC resource query didn't return all results")
 	// build a lookup map from search results by ID for order-independent matching
 	searchResultsByID := make(map[string]map[string]any)

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -789,7 +789,7 @@ func TestDescriptors(t *testing.T) {
 	assert.NotNil(results, "NMDC search query did not return results")
 	fileIds := make([]string, len(results.Descriptors))
 	for i, descriptor := range results.Descriptors {
-		fileIds[i] = studyId + strings.Replace(descriptor["id"].(string), "nmdc:", "", 1)
+		fileIds[i] = descriptor["id"].(string)
 	}
 	descriptors, err := db.Descriptors(testOrcid, fileIds[:expectedCount])
 	if areValidCredentials {
@@ -824,29 +824,6 @@ func TestDescriptors(t *testing.T) {
 		assert.Equal(nmdcSearchResult["credit"].(credit.CreditMetadata).Identifier, desc["credit"].(credit.CreditMetadata).Identifier, "Resource credit ID mismatch")
 		assert.Equal(nmdcSearchResult["credit"].(credit.CreditMetadata).ResourceType, desc["credit"].(credit.CreditMetadata).ResourceType, "Resource credit resource type mismatch")
 	}
-}
-
-func TestDataObjects(t *testing.T) {
-	assert := assert.New(t)
-	if areValidCredentials {
-		// skip mock server tests
-		return
-	}
-	db := getMockNmdcDatabase(t)
-	dbNmdc := db.(*Database)
-	params := url.Values{}
-	params.Add("sample_id", "nmdc:bs-1234-abcde56789")
-	dataObjects, err := dbNmdc.dataObjects(params)
-	assert.Nil(err, "dataObjects encountered an error")
-	assert.Equal(2, len(dataObjects), "dataObjects returned incorrect number of data objects")
-	assert.Equal("nmdc:do-1234-abcde56789", dataObjects[0].Id, "dataObjects returned incorrect first data object ID")
-	assert.Equal("nmdc:do-5678-efghij12345", dataObjects[1].Id, "dataObjects returned incorrect second data object ID")
-
-	// include unsupported extra fields in search params
-	params.Add("extra", "some_field,some_other_field")
-	dataObjects, err = dbNmdc.dataObjects(params)
-	assert.NotNil(err, "dataObjects with unsupported field did not encounter an error")
-	assert.Nil(dataObjects, "dataObjects with unsupported field returned data objects")
 }
 
 func TestCreateDataObjectDescriptor(t *testing.T) {

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -772,8 +772,9 @@ func TestDescriptors(t *testing.T) {
 		db = getMockNmdcDatabase(t)
 		expectedCount = 2
 	}
+	studyId := "nmdc:sty-11-r2h77870"
 	params := databases.SearchParameters{
-		Query: "nmdc:sty-11-r2h77870",
+		Query: studyId,
 	}
 	results, err := db.Search(testOrcid, params)
 	if areValidCredentials {
@@ -788,7 +789,7 @@ func TestDescriptors(t *testing.T) {
 	assert.NotNil(results, "NMDC search query did not return results")
 	fileIds := make([]string, len(results.Descriptors))
 	for i, descriptor := range results.Descriptors {
-		fileIds[i] = descriptor["id"].(string)
+		fileIds[i] = studyId + strings.Replace(descriptor["id"].(string), "nmdc:", "", 1)
 	}
 	descriptors, err := db.Descriptors(testOrcid, fileIds[:expectedCount])
 	if areValidCredentials {

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -997,12 +997,6 @@ func TestCreditAndBiosamplesForWorkflow(t *testing.T) {
 	assert.NotNil(err, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should error")
 	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should return no credit")
 	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should return no biosample")
-
-	// check workflow with too many biosamples
-	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:wf-too-many-biosamples")
-	assert.NotNil(err, "creditAndBiosampleForWorkflow with workflow ID having too many biosamples should error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with workflow ID having too many biosamples should return no credit")
-	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with workflow ID having too many biosamples should return no biosample")
 }
 
 func TestCreditMetadataForStudy(t *testing.T) {

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -951,7 +951,7 @@ func TestCreateDataObjectDescriptor(t *testing.T) {
 	assert.Equal(dataObject.URL, creditMeta.Url, "Data object descriptor credit URL mismatch")
 }
 
-func TestCreditAndBiosampleForWorkflow(t *testing.T) {
+func TestCreditAndBiosamplesForWorkflow(t *testing.T) {
 	assert := assert.New(t)
 	if areValidCredentials {
 		// skip mock server tests
@@ -961,47 +961,48 @@ func TestCreditAndBiosampleForWorkflow(t *testing.T) {
 	dbNmdc := db.(*Database)
 
 	// check no workflow id
-	relatedCredit, relatedBiosample, err := dbNmdc.creditAndBiosampleForWorkflow("")
-	assert.Nil(err, "creditAndBiosampleForWorkflow with no workflow ID should not error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosampleForWorkflow with no workflow ID should return no credit")
-	assert.Nil(relatedBiosample, "creditAndBiosampleForWorkflow with no workflow ID should return no biosample")
+	relatedCredit, relatedBiosamples, err := dbNmdc.creditAndBiosamplesForWorkflow("")
+	assert.Nil(err, "creditAndBiosamplesForWorkflow with no workflow ID should not error")
+	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with no workflow ID should return no credit")
+	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with no workflow ID should return no biosamples")
 
 	// check valid workflow id
-	relatedCredit, relatedBiosample, err = dbNmdc.creditAndBiosampleForWorkflow("nmdc:wf-1234-abcde56789")
-	assert.Nil(err, "creditAndBiosampleForWorkflow with valid workflow ID should not error")
+	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:wf-1234-abcde56789")
+	assert.Nil(err, "creditAndBiosamplesForWorkflow with valid workflow ID should not error")
 	assert.Equal("", relatedCredit.Identifier,
-		"creditAndBiosampleForWorkflow returned non-empty credit identifier")
+		"creditAndBiosamplesForWorkflow returned non-empty credit identifier")
 	assert.Equal("Tara Oceans Mediterranean Sea Expedition 2013", relatedCredit.Titles[0].Title,
-		"creditAndBiosampleForWorkflow returned incorrect credit name")
+		"creditAndBiosamplesForWorkflow returned incorrect credit name")
 	assert.Equal("dataset", relatedCredit.ResourceType,
-		"creditAndBiosampleForWorkflow returned incorrect credit resource type")
-	assert.NotNil(relatedBiosample, "creditAndBiosampleForWorkflow with valid workflow ID should return biosample")
-	assert.Equal("nmdc:bs-1234-abcde56789", relatedBiosample["id"],
-		"creditAndBiosampleForWorkflow returned incorrect biosample ID")
+		"creditAndBiosamplesForWorkflow returned incorrect credit resource type")
+	assert.NotNil(relatedBiosamples, "creditAndBiosamplesForWorkflow with valid workflow ID should return biosample")
+	assert.Equal(1, len(relatedBiosamples), "creditAndBiosamplesForWorkflow returned incorrect number of biosamples")
+	assert.Equal("nmdc:bs-1234-abcde56789", relatedBiosamples[0]["id"],
+		"creditAndBiosamplesForWorkflow returned incorrect biosample ID")
 
 	// check invalid workflow id indicating raw data
-	relatedCredit, relatedBiosample, err = dbNmdc.creditAndBiosampleForWorkflow("nmdc:omg-invalid-workflow-id")
-	assert.Nil(err, "creditAndBiosampleForWorkflow with invalid workflow ID should not error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosampleForWorkflow with invalid workflow ID should return no credit")
-	assert.Nil(relatedBiosample, "creditAndBiosampleForWorkflow with invalid workflow ID should return no biosample")
+	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:omg-invalid-workflow-id")
+	assert.Nil(err, "creditAndBiosamplesForWorkflow with invalid workflow ID should not error")
+	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with invalid workflow ID should return no credit")
+	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with invalid workflow ID should return no biosample")
 
 	// check with invalid workflow id format
-	relatedCredit, relatedBiosample, err = dbNmdc.creditAndBiosampleForWorkflow("invalid-workflow-id-format")
-	assert.Nil(err, "creditAndBiosampleForWorkflow with invalid workflow ID format should not error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosampleForWorkflow with invalid workflow ID format should return no credit")
-	assert.Nil(relatedBiosample, "creditAndBiosampleForWorkflow with invalid workflow ID format should return no biosample")
+	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("invalid-workflow-id-format")
+	assert.Nil(err, "creditAndBiosamplesForWorkflow with invalid workflow ID format should not error")
+	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with invalid workflow ID format should return no credit")
+	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with invalid workflow ID format should return no biosample")
 
 	// check workflow with too many studies
-	relatedCredit, relatedBiosample, err = dbNmdc.creditAndBiosampleForWorkflow("nmdc:wf-too-many-studies")
-	assert.NotNil(err, "creditAndBiosampleForWorkflow with workflow ID having too many studies should error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosampleForWorkflow with workflow ID having too many studies should return no credit")
-	assert.Nil(relatedBiosample, "creditAndBiosampleForWorkflow with workflow ID having too many studies should return no biosample")
+	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:wf-too-many-studies")
+	assert.NotNil(err, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should error")
+	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should return no credit")
+	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should return no biosample")
 
 	// check workflow with too many biosamples
-	relatedCredit, relatedBiosample, err = dbNmdc.creditAndBiosampleForWorkflow("nmdc:wf-too-many-biosamples")
+	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:wf-too-many-biosamples")
 	assert.NotNil(err, "creditAndBiosampleForWorkflow with workflow ID having too many biosamples should error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosampleForWorkflow with workflow ID having too many biosamples should return no credit")
-	assert.Nil(relatedBiosample, "creditAndBiosampleForWorkflow with workflow ID having too many biosamples should return no biosample")
+	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with workflow ID having too many biosamples should return no credit")
+	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with workflow ID having too many biosamples should return no biosample")
 }
 
 func TestCreditMetadataForStudy(t *testing.T) {

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -835,6 +835,7 @@ func TestCreateDataObjectDescriptor(t *testing.T) {
 	db := getMockNmdcDatabase(t)
 	dataObject := DataObject{
 		Id:            "nmdc:do-1234-abcde56789",
+		StudyId:       "nmdc:study_id", // needed here because of internal machinery
 		Name:          "Test Data Object.txt",
 		Description:   "This is a test data object",
 		FileSizeBytes: 123456,
@@ -849,9 +850,9 @@ func TestCreateDataObjectDescriptor(t *testing.T) {
 	}
 	nmdcDb := db.(*Database)
 	descriptor := nmdcDb.createDataObjectDescriptor(dataObject, studyCredit)
-	assert.Equal(dataObject.Id, descriptor["id"], "Data object descriptor ID mismatch")
+	assert.True(strings.Contains(descriptor["id"].(string), dataObject.Id), "Data object descriptor ID mismatch")
 	assert.Equal("test_data_object", descriptor["name"], "Data object descriptor name mismatch")
-	assert.Equal("nmdc%3Ado-1234-abcde56789", descriptor["path"], "Data object descriptor path mismatch")
+	assert.Equal("nmdc\\:do-1234-abcde56789", descriptor["path"], "Data object descriptor path mismatch")
 	assert.Equal("application/octet-stream", descriptor["mediatype"], "Data object descriptor media type mismatch")
 	assert.Equal(dataObject.FileSizeBytes, descriptor["bytes"], "Data object descriptor size mismatch")
 	creditMeta, ok := descriptor["credit"].(credit.CreditMetadata)

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -874,48 +874,6 @@ func TestDataObjects(t *testing.T) {
 	assert.Nil(dataObjects, "dataObjects with unsupported field returned data objects")
 }
 
-func TestCreateDataObjectAndBiosampleDescriptors(t *testing.T) {
-	assert := assert.New(t)
-	if areValidCredentials {
-		// skip mock server tests
-		return
-	}
-	db := getMockNmdcDatabase(t)
-	dbNmdc := db.(*Database)
-
-	dataObjects := []DataObject{
-		{
-			Id:             "nmdc:do-1234-abcde56789",
-			Name:           "Test Data Object 1.txt",
-			Description:    "This is test data object 1",
-			FileSizeBytes:  123456,
-			MD5Checksum:    "d41d8cd98f00b204e9800998ecf8427e",
-			URL:            "https://data.microbiomedata.org/data/nmdc:do-1234-abcde56789",
-			Type:           "data_object",
-			WasGeneratedBy: "nmdc:wf-1234-abcde56789",
-		},
-		{
-			Id:             "nmdc:do-5678-efghij12345",
-			Name:           "Test Data Object 2.txt",
-			Description:    "This is test data object 2",
-			FileSizeBytes:  654321,
-			MD5Checksum:    "0cc175b9c0f1b6a831c399e269772661",
-			URL:            "https://data.microbiomedata.org/data/nmdc:do-5678-efghij12345",
-			Type:           "data_object",
-			WasGeneratedBy: "nmdc:wf-1234-abcde56789",
-		},
-	}
-	dataDesc, bioDesc, err := dbNmdc.createDataObjectAndBiosampleDescriptors(dataObjects)
-	assert.Nil(err, "createDataObjectAndBiosampleDescriptors encountered an error")
-	assert.Equal(2, len(dataDesc), "createDataObjectAndBiosampleDescriptors returned incorrect number of data object descriptors")
-	assert.Equal("nmdc:do-1234-abcde56789", dataDesc[0]["id"], "createDataObjectAndBiosampleDescriptors returned incorrect first data object ID")
-	assert.Equal("nmdc:do-5678-efghij12345", dataDesc[1]["id"], "createDataObjectAndBiosampleDescriptors returned incorrect second data object ID")
-	assert.NotNil(bioDesc, "createDataObjectAndBiosampleDescriptors returned nil biosample descriptor")
-	assert.Equal(2, len(bioDesc), "createDataObjectAndBiosampleDescriptors returned incorrect number of biosample descriptors")
-	assert.Equal("biosample-metadata-for-study-nmdc:sty-11-r2h77870", bioDesc[0]["name"], "createDataObjectAndBiosampleDescriptors returned incorrect biosample ID")
-	assert.Equal("biosample-metadata-for-study-nmdc:sty-22-x3y4z56789", bioDesc[1]["name"], "createDataObjectAndBiosampleDescriptors returned incorrect biosample ID")
-}
-
 func TestCreateDataObjectDescriptor(t *testing.T) {
 	assert := assert.New(t)
 	if areValidCredentials {
@@ -949,54 +907,6 @@ func TestCreateDataObjectDescriptor(t *testing.T) {
 	assert.Equal(dataObject.Id, creditMeta.Identifier, "Data object descriptor credit ID mismatch")
 	assert.Equal(studyCredit.ResourceType, creditMeta.ResourceType, "Data object descriptor credit resource type mismatch")
 	assert.Equal(dataObject.URL, creditMeta.Url, "Data object descriptor credit URL mismatch")
-}
-
-func TestCreditAndBiosamplesForWorkflow(t *testing.T) {
-	assert := assert.New(t)
-	if areValidCredentials {
-		// skip mock server tests
-		return
-	}
-	db := getMockNmdcDatabase(t)
-	dbNmdc := db.(*Database)
-
-	// check no workflow id
-	relatedCredit, relatedBiosamples, err := dbNmdc.creditAndBiosamplesForWorkflow("")
-	assert.Nil(err, "creditAndBiosamplesForWorkflow with no workflow ID should not error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with no workflow ID should return no credit")
-	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with no workflow ID should return no biosamples")
-
-	// check valid workflow id
-	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:wf-1234-abcde56789")
-	assert.Nil(err, "creditAndBiosamplesForWorkflow with valid workflow ID should not error")
-	assert.Equal("", relatedCredit.Identifier,
-		"creditAndBiosamplesForWorkflow returned non-empty credit identifier")
-	assert.Equal("Tara Oceans Mediterranean Sea Expedition 2013", relatedCredit.Titles[0].Title,
-		"creditAndBiosamplesForWorkflow returned incorrect credit name")
-	assert.Equal("dataset", relatedCredit.ResourceType,
-		"creditAndBiosamplesForWorkflow returned incorrect credit resource type")
-	assert.NotNil(relatedBiosamples, "creditAndBiosamplesForWorkflow with valid workflow ID should return biosample")
-	assert.Equal(1, len(relatedBiosamples), "creditAndBiosamplesForWorkflow returned incorrect number of biosamples")
-	assert.Equal("nmdc:bs-1234-abcde56789", relatedBiosamples[0]["id"],
-		"creditAndBiosamplesForWorkflow returned incorrect biosample ID")
-
-	// check invalid workflow id indicating raw data
-	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:omg-invalid-workflow-id")
-	assert.Nil(err, "creditAndBiosamplesForWorkflow with invalid workflow ID should not error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with invalid workflow ID should return no credit")
-	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with invalid workflow ID should return no biosample")
-
-	// check with invalid workflow id format
-	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("invalid-workflow-id-format")
-	assert.Nil(err, "creditAndBiosamplesForWorkflow with invalid workflow ID format should not error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with invalid workflow ID format should return no credit")
-	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with invalid workflow ID format should return no biosample")
-
-	// check workflow with too many studies
-	relatedCredit, relatedBiosamples, err = dbNmdc.creditAndBiosamplesForWorkflow("nmdc:wf-too-many-studies")
-	assert.NotNil(err, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should error")
-	assert.Equal(credit.CreditMetadata{}, relatedCredit, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should return no credit")
-	assert.Nil(relatedBiosamples, "creditAndBiosamplesForWorkflow with workflow ID having too many studies should return no biosample")
 }
 
 func TestCreditMetadataForStudy(t *testing.T) {
@@ -1047,7 +957,8 @@ func TestCreditMetadataForStudy(t *testing.T) {
 			"NSF",
 		},
 	}
-	credit := db.creditMetadataForStudy(study)
+	credit, err := db.creditMetadataForStudy(study.Id)
+	assert.Nil(err, "Credit metadata retrieval failed")
 	assert.Equal("Jane Doe", credit.Contributors[0].Name,
 		"Credit metadata first contributor name is incorrect")
 	assert.Equal("Jane", credit.Contributors[0].GivenName,

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -826,42 +826,6 @@ func TestDescriptors(t *testing.T) {
 	}
 }
 
-func TestCreateDataObjectDescriptor(t *testing.T) {
-	assert := assert.New(t)
-	if areValidCredentials {
-		// skip mock server tests
-		return
-	}
-	db := getMockNmdcDatabase(t)
-	dataObject := DataObject{
-		Id:            "nmdc:do-1234-abcde56789",
-		StudyId:       "nmdc:study_id", // needed here because of internal machinery
-		Name:          "Test Data Object.txt",
-		Description:   "This is a test data object",
-		FileSizeBytes: 123456,
-		MD5Checksum:   "d41d8cd98f00b204e9800998ecf8427e",
-		URL:           "https://data.microbiomedata.org/data/nmdc:do-1234-abcde56789",
-		Type:          "data_object",
-	}
-	studyCredit := credit.CreditMetadata{
-		Identifier:   "original-study-id",
-		ResourceType: "study",
-		Url:          "original-study-url",
-	}
-	nmdcDb := db.(*Database)
-	descriptor := nmdcDb.createDataObjectDescriptor(dataObject, studyCredit)
-	assert.True(strings.Contains(descriptor["id"].(string), dataObject.Id), "Data object descriptor ID mismatch")
-	assert.Equal("test_data_object", descriptor["name"], "Data object descriptor name mismatch")
-	assert.Equal("nmdc\\:do-1234-abcde56789", descriptor["path"], "Data object descriptor path mismatch")
-	assert.Equal("application/octet-stream", descriptor["mediatype"], "Data object descriptor media type mismatch")
-	assert.Equal(dataObject.FileSizeBytes, descriptor["bytes"], "Data object descriptor size mismatch")
-	creditMeta, ok := descriptor["credit"].(credit.CreditMetadata)
-	assert.True(ok, "Data object descriptor credit type assertion failed")
-	assert.Equal(dataObject.Id, creditMeta.Identifier, "Data object descriptor credit ID mismatch")
-	assert.Equal(studyCredit.ResourceType, creditMeta.ResourceType, "Data object descriptor credit resource type mismatch")
-	assert.Equal(dataObject.URL, creditMeta.Url, "Data object descriptor credit URL mismatch")
-}
-
 func TestCreditMetadataForStudy(t *testing.T) {
 	assert := assert.New(t)
 	db := Database{

--- a/databases/nmdc/database_test.go
+++ b/databases/nmdc/database_test.go
@@ -240,10 +240,6 @@ var mockNmdcSecret string = "testsecret"
 var mockNerscEndpoint string = "globus-nmdc-nersc"
 var mockEmslEndpoint string = "globus-nmdc-emsl"
 
-// since NMDC doesn't support search queries at this time, we search for
-// data objects related to a study
-var nmdcSearchParams map[string]any
-
 // Creates a mock NMDC server for testing
 func createMockNmdcServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -547,10 +543,6 @@ func setup() {
 	}
 	endpoints.RegisterEndpointProvider("globus", globus.EndpointConstructor)
 
-	// construct NMDC-specific search parameters for a study
-	nmdcSearchParams = make(map[string]any)
-	nmdcSearchParams["study_id"] = "nmdc:sty-11-r2h77870"
-
 	// check for valid NMDC credentials
 	orcid := os.Getenv("DTS_KBASE_TEST_ORCID")
 	if orcid != "" {
@@ -657,8 +649,7 @@ func TestSearch(t *testing.T) {
 	assert.Contains(endpointNames, mockEmslEndpoint, "NMDC database missing EMSL endpoint")
 
 	params := databases.SearchParameters{
-		Query:    "",
-		Specific: nmdcSearchParams,
+		Query: "nmdc:sty-11-r2h77870",
 	}
 	results, err := db.Search(testOrcid, params)
 
@@ -675,22 +666,6 @@ func TestSearch(t *testing.T) {
 		assert.True(len(results.Descriptors) >= 2,
 			"NMDC search query didn't return all results")
 	}
-
-	// check with parameters that don't include a study_id
-	if areValidCredentials {
-		// skip mock server tests
-		return
-	}
-	mockDb := getMockNmdcDatabase(t)
-	params = databases.SearchParameters{
-		Query: "",
-		Specific: map[string]any{
-			"sample_id": "nmdc:bs-1234-abcde56789",
-		},
-	}
-	results, err = mockDb.Search(testOrcid, params)
-	assert.Nil(err, "NMDC search query without study_id encountered an error")
-	assert.NotNil(results, "NMDC search query without study_id did not return results")
 }
 
 func TestSimpleFunctions(t *testing.T) {
@@ -798,8 +773,7 @@ func TestDescriptors(t *testing.T) {
 		expectedCount = 2
 	}
 	params := databases.SearchParameters{
-		Query:    "",
-		Specific: nmdcSearchParams,
+		Query: "nmdc:sty-11-r2h77870",
 	}
 	results, err := db.Search(testOrcid, params)
 	if areValidCredentials {
@@ -911,7 +885,9 @@ func TestCreateDataObjectDescriptor(t *testing.T) {
 
 func TestCreditMetadataForStudy(t *testing.T) {
 	assert := assert.New(t)
-	db := Database{}
+	db := Database{
+		BaseURL: defaultBaseApiURL,
+	}
 	study := Study{
 		Id:    "nmdc:sty-11-r2h77870",
 		Title: "Primary Title",
@@ -959,60 +935,52 @@ func TestCreditMetadataForStudy(t *testing.T) {
 	}
 	credit, err := db.creditMetadataForStudy(study.Id)
 	assert.Nil(err, "Credit metadata retrieval failed")
-	assert.Equal("Jane Doe", credit.Contributors[0].Name,
+	assert.Equal("Mitchel J. Doktycz", credit.Contributors[0].Name,
 		"Credit metadata first contributor name is incorrect")
-	assert.Equal("Jane", credit.Contributors[0].GivenName,
+	assert.Equal("Mitchel", credit.Contributors[0].GivenName,
 		"Credit metadata first contributor given name is incorrect")
-	assert.Equal("Doe", credit.Contributors[0].FamilyName,
+	assert.Equal("Doktycz", credit.Contributors[0].FamilyName,
 		"Credit metadata first contributor family name is incorrect")
-	assert.Equal("creator", credit.Contributors[0].ContributorRoles,
+	assert.Equal("Principal Investigator,Conceptualization", credit.Contributors[0].ContributorRoles,
 		"Credit metadata first contributor role is incorrect")
-	assert.Equal("John Smith", credit.Contributors[1].Name,
+	assert.Equal("Joseph C. Ellis", credit.Contributors[1].Name,
 		"Credit metadata second contributor name is incorrect")
-	assert.Equal("John", credit.Contributors[1].GivenName,
+	assert.Equal("Joseph", credit.Contributors[1].GivenName,
 		"Credit metadata second contributor given name is incorrect")
-	assert.Equal("Smith", credit.Contributors[1].FamilyName,
+	assert.Equal("Ellis", credit.Contributors[1].FamilyName,
 		"Credit metadata second contributor family name is incorrect")
-	assert.Equal("0000-0002-1825-0097", credit.Contributors[1].ContributorId,
+	assert.Equal("orcid:0000-0002-2510-977X", credit.Contributors[1].ContributorId,
 		"Credit metadata second contributor ORCID is incorrect")
-	assert.Equal("contributor,tester", credit.Contributors[1].ContributorRoles,
+	assert.Equal("Formal Analysis", credit.Contributors[1].ContributorRoles,
 		"Credit metadata second contributor first role is incorrect")
-	assert.Equal("Cher", credit.Contributors[2].Name,
+	assert.Equal("Daniel Jacobson", credit.Contributors[2].Name,
 		"Credit metadata third contributor name is incorrect")
-	assert.Equal("Cher", credit.Contributors[2].GivenName,
+	assert.Equal("Daniel", credit.Contributors[2].GivenName,
 		"Credit metadata third contributor given name is incorrect")
-	assert.Equal("", credit.Contributors[2].FamilyName,
+	assert.Equal("Jacobson", credit.Contributors[2].FamilyName,
 		"Credit metadata third contributor family name is incorrect")
-	assert.Equal("singer", credit.Contributors[2].ContributorRoles,
+	assert.Equal("Conceptualization,Formal Analysis,Funding acquisition,Investigation,Methodology,Supervision,Writing original draft,Writing review and editing", credit.Contributors[2].ContributorRoles,
 		"Credit metadata third contributor role is incorrect")
-	assert.Equal("Primary Title", credit.Titles[0].Title,
+	assert.Equal("Bio-Scales: Defining plant gene function and its connection to ecosystem nitrogen and carbon cycle", credit.Titles[0].Title,
 		"Credit metadata primary title is incorrect")
-	assert.Equal("Secondary Title", credit.Titles[1].Title,
-		"Credit metadata first alternative title is incorrect")
-	assert.Equal("Tertiary Title", credit.Titles[2].Title,
-		"Credit metadata second alternative title is incorrect")
-	assert.Equal("10.1234/example.doi.1", credit.RelatedIdentifiers[0].Id,
+	assert.Equal("doi:10.46936/10.25585/60000017", credit.RelatedIdentifiers[0].Id,
 		"Credit metadata primary DOI is incorrect")
 	assert.Equal("IsCitedBy", credit.RelatedIdentifiers[0].RelationshipType,
 		"Credit metadata primary DOI relationship type is incorrect")
-	assert.Equal("", credit.RelatedIdentifiers[0].Description,
+	assert.Equal("Awarded proposal DOI", credit.RelatedIdentifiers[0].Description,
 		"Credit metadata primary DOI description is incorrect")
-	assert.Equal("10.5678/example.doi.2", credit.RelatedIdentifiers[1].Id,
+	assert.Equal("doi:10.25345/C58K7520G", credit.RelatedIdentifiers[1].Id,
 		"Credit metadata dataset DOI is incorrect")
 	assert.Equal("IsCitedBy", credit.RelatedIdentifiers[1].RelationshipType,
 		"Credit metadata dataset DOI relationship type is incorrect")
 	assert.Equal("Dataset DOI", credit.RelatedIdentifiers[1].Description,
 		"Credit metadata dataset DOI description is incorrect")
-	assert.Equal(2, len(credit.Funding),
+	assert.Equal(1, len(credit.Funding),
 		"Credit metadata funding source count is incorrect")
 	assert.Equal("ROR:01bj3aw27", credit.Funding[0].Funder.OrganizationId,
 		"Credit metadata first funding source organization ID is incorrect")
 	assert.Equal("United States Department of Energy", credit.Funding[0].Funder.OrganizationName,
 		"Credit metadata first funding source name is incorrect")
-	assert.Equal("", credit.Funding[1].Funder.OrganizationId,
-		"Unrecognized funding source should have empty Funder instance")
-	assert.Equal("", credit.Funding[1].Funder.OrganizationName,
-		"Unrecognized funding source should have empty Funder instance")
 }
 
 func TestPageNumberAndSize(t *testing.T) {
@@ -1095,17 +1063,17 @@ func TestDataResourceName(t *testing.T) {
 
 func TestAddSpecificSearchParameters(t *testing.T) {
 	assert := assert.New(t)
-	db := Database{}
+	db := Database{
+		BaseURL: defaultBaseApiURL,
+	}
 	validParams := map[string]any{
-		"study_id":       "nmdc:sty-11-r2h77870",
 		"data_object_id": "nmdc:do-1234-abcde56789",
 	}
 	p := url.Values{}
+	p.Set("Query", "nmdc:sty-11-r2h77870")
 	p.Set("existing_param", "existing_value")
 	err := db.addSpecificSearchParameters(validParams, &p)
 	assert.Nil(err, "Adding NMDC specific search parameters encountered an error")
-	assert.Equal("nmdc:sty-11-r2h77870", p.Get("study_id"),
-		"NMDC specific search parameter 'study_id' has incorrect value")
 	assert.Equal("nmdc:do-1234-abcde56789", p.Get("data_object_id"),
 		"NMDC specific search parameter 'data_object_id' has incorrect value")
 	assert.Equal("existing_value", p.Get("existing_param"),
@@ -1113,12 +1081,11 @@ func TestAddSpecificSearchParameters(t *testing.T) {
 
 	invalidParams := []map[string]any{
 		{"invalid_param": "some_value"},
-		{"study_id": 12345},                                     // invalid type
 		{"data_object_id": []string{"nmdc:do-1234-abcde56789"}}, // invalid type
 		{"extra": "invalid_field,other_invalid_field"},          // invalid value
-		{"extra": 23456},                                        // invalid type
-		{"fields": "invalid_field"},                             // invalid value
-		{"fields": 34567},                                       // invalid type
+		{"extra": 23456},            // invalid type
+		{"fields": "invalid_field"}, // invalid value
+		{"fields": 34567},           // invalid type
 	}
 	for _, params := range invalidParams {
 		p := url.Values{}

--- a/databases/nmdc/errors.go
+++ b/databases/nmdc/errors.go
@@ -56,7 +56,7 @@ func (e TooManyRecordsError) Error() string {
 		e.ResourceType, e.Identifier, e.Count)
 }
 
-// This error type indicates unsupported extra fields were included in a NMDC search.
+// This error type indicates unsupported extra fields were included in a search.
 type ExtraFieldsInSearchError struct {
 	StudyID string
 	Fields  []string

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -329,7 +329,7 @@ func (ep *Endpoint) Status(id uuid.UUID) (endpoints.TransferStatus, error) {
 				if event.IsError {
 					// does this error indicate that the transfer has failed?
 					switch event.Code {
-					case "FILE_NOT_FOUND": // requested file is not where we thought!
+					case "FILE_NOT_FOUND", "PERMISSION_DENIED":
 						return endpoints.TransferStatus{
 							Code:                endpoints.TransferStatusFailed,
 							Message:             fmt.Sprintf("Transfer failed: %s (%s)", event.Description, event.Details),
@@ -337,7 +337,7 @@ func (ep *Endpoint) Status(id uuid.UUID) (endpoints.TransferStatus, error) {
 							NumFilesSkipped:     response.FilesSkipped,
 							NumFilesTransferred: response.FilesTransferred,
 						}, nil
-					default: // just propagate other errors
+					default: // not sure what this is -- just propagate
 						return endpoints.TransferStatus{},
 							fmt.Errorf("%s (%s):\n%s", event.Description, event.Code,
 								event.Details)

--- a/endpoints/globus/endpoint.go
+++ b/endpoints/globus/endpoint.go
@@ -314,6 +314,9 @@ func (ep *Endpoint) Status(id uuid.UUID) (endpoints.TransferStatus, error) {
 		var eventList EventList
 		json.Unmarshal(body, &eventList)
 		if response.NiceStatus == "AUTH" {
+			// sometimes Globus throws an AUTH error here during a network burp, so we
+			// ignore it and report a failed status check (after all, we can't get here
+			// without AUTHing successfully!)
 			for _, event := range eventList.Data {
 				if event.IsError {
 					slog.Debug(fmt.Sprintf("Globus task %s: status check failed with AUTH error below (probably bogus, ignoring): ", id.String()))
@@ -321,16 +324,24 @@ func (ep *Endpoint) Status(id uuid.UUID) (endpoints.TransferStatus, error) {
 				}
 			}
 		} else {
-			// it's probably real
-			// find the first error event
+			// it's probably real, so find the first error event
 			for _, event := range eventList.Data {
 				if event.IsError {
-					// sometimes Globus throws an AUTH error here during a network burp, so we
-					// ignore it and report a failed status check (after all, we can't get here
-					// without AUTHing successfully!)
-					return endpoints.TransferStatus{},
-						fmt.Errorf("%s (%s):\n%s", event.Description, event.Code,
-							event.Details)
+					// does this error indicate that the transfer has failed?
+					switch event.Code {
+					case "FILE_NOT_FOUND": // requested file is not where we thought!
+						return endpoints.TransferStatus{
+							Code:                endpoints.TransferStatusFailed,
+							Message:             fmt.Sprintf("Transfer failed: %s (%s)", event.Description, event.Details),
+							NumFiles:            response.Files,
+							NumFilesSkipped:     response.FilesSkipped,
+							NumFilesTransferred: response.FilesTransferred,
+						}, nil
+					default: // just propagate other errors
+						return endpoints.TransferStatus{},
+							fmt.Errorf("%s (%s):\n%s", event.Description, event.Code,
+								event.Details)
+					}
 				}
 			}
 			// fall back to the "nice status"

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -404,7 +404,8 @@ func databaseError(err error) error {
 	if err != nil {
 		slog.Error(err.Error())
 		switch err.(type) {
-		case *transfers.NoFilesRequestedError, *databases.InvalidSearchParameter:
+		case *transfers.NoFilesRequestedError, *databases.InvalidSearchQuery,
+			*databases.InvalidSearchParameter, *databases.InvalidResourceIdError:
 			return huma.Error400BadRequest(err.Error(), err)
 		case *databases.PermissionDeniedError, *databases.UnauthorizedError, *transfers.InvalidOrcidError:
 			return huma.Error401Unauthorized(err.Error(), err)
@@ -576,7 +577,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 	// is the database valid?
 	_, ok := config.Databases[input.Database]
 	if !ok {
-		return nil, fmt.Errorf("database %s not found", input.Database)
+		return nil, huma.Error404NotFound(fmt.Sprintf("database %s not found", input.Database))
 	}
 
 	// have we been given any IDs?
@@ -596,7 +597,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 		len(ids), input.Database))
 	db, err := databases.NewDatabase(input.Database)
 	if err != nil {
-		return nil, err
+		return nil, databaseError(err)
 	}
 
 	// FIXME: for now, if a user ORCID is not specified, use the authorized user's ORCID
@@ -608,7 +609,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 	descriptors, err := db.Descriptors(orcid, ids)
 	if err != nil {
 		slog.Error(err.Error())
-		return nil, err
+		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
 	// validate the descriptors and send them along
@@ -616,7 +617,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 		err = validator.Validate(descriptor, "data-resource", validator.MustInMemoryRegistry())
 		if err != nil {
 			slog.Error(err.Error())
-			return nil, err
+			return nil, huma.Error500InternalServerError(err.Error())
 		}
 	}
 	return &FileMetadataOutput{

--- a/services/version.go
+++ b/services/version.go
@@ -7,7 +7,7 @@ import (
 // Version numbers
 var majorVersion = 0
 var minorVersion = 11
-var patchVersion = 2
+var patchVersion = 3
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)

--- a/transfers/manifestor.go
+++ b/transfers/manifestor.go
@@ -190,8 +190,17 @@ func (m *manifestorState) generateAndSendManifest(transferId uuid.UUID) (manifes
 	if err != nil {
 		return manifestEntry{}, err
 	}
+	oldStatus, err := store.GetStatus(transferId)
+	if err != nil {
+		return manifestEntry{}, err
+	}
+	newStatus := oldStatus // in case an operation causes a transfer failure
+
 	manifest, err := m.generateManifest(transferId, spec)
 	if err != nil {
+		newStatus.Code = TransferStatusFailed
+		newStatus.Message = fmt.Sprintf("couldn't generate manifest: %s", err.Error())
+		store.SetStatus(transferId, newStatus)
 		return manifestEntry{}, err
 	}
 
@@ -200,15 +209,24 @@ func (m *manifestorState) generateAndSendManifest(transferId uuid.UUID) (manifes
 	if ok && len(resources) > 0 {
 		pkg, err := datapackage.New(manifest, ".")
 		if err != nil {
+			newStatus.Code = TransferStatusFailed
+			newStatus.Message = fmt.Sprintf("manifest failed validation: %s", err.Error())
+			store.SetStatus(transferId, newStatus)
 			return manifestEntry{}, err
 		}
 		if err := pkg.SaveDescriptor(filename); err != nil {
+			newStatus.Code = TransferStatusFailed
+			newStatus.Message = fmt.Sprintf("couldn't create manifest file: %s", err.Error())
+			store.SetStatus(transferId, newStatus)
 			return manifestEntry{}, fmt.Errorf("creating manifest file: %s", err.Error())
 		}
 	} else {
 		// if no resources were transferred, just create an empty file
 		f, err := os.Create(filename)
 		if err != nil {
+			newStatus.Code = TransferStatusFailed
+			newStatus.Message = fmt.Sprintf("couldn't create manifest file: %s", err.Error())
+			store.SetStatus(transferId, newStatus)
 			return manifestEntry{}, fmt.Errorf("creating manifest file: %s", err.Error())
 		}
 		f.Close()

--- a/transfers/mover.go
+++ b/transfers/mover.go
@@ -354,12 +354,14 @@ func (m *moverState) updateStatus(transferId uuid.UUID, moves []moveOperation) (
 		if err := store.SetStatus(transferId, newStatus); err != nil {
 			return newStatus, err
 		}
-		publish(Message{
-			Description:    newStatus.Message,
-			TransferId:     transferId,
-			TransferStatus: newStatus,
-			Time:           time.Now(),
-		})
+		if newStatus.Code != oldStatus.Code {
+			publish(Message{
+				Description:    newStatus.Message,
+				TransferId:     transferId,
+				TransferStatus: newStatus,
+				Time:           time.Now(),
+			})
+		}
 	}
 
 	return newStatus, nil

--- a/transfers/mover.go
+++ b/transfers/mover.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -181,7 +182,11 @@ func (m *moverState) process(decoder *gob.Decoder) {
 						if err != nil {
 							slog.Error(err.Error())
 						}
-					} else { // failed -- write an entry to the journal
+					}
+					if status, err = store.GetStatus(transferId); err != nil {
+						slog.Error(err.Error())
+					}
+					if status.Code == TransferStatusFailed { // failed -- write an entry to the journal
 						spec, err := store.GetSpecification(transferId)
 						if err == nil {
 							var size uint64
@@ -249,7 +254,7 @@ func (m *moverState) moveFiles(transferId uuid.UUID) ([]moveOperation, error) {
 			path := descriptor["path"].(string)
 			destinationPath := filepath.Join(destinationFolder, path)
 			files[i] = endpoints.FileTransfer{
-				SourcePath:      path,
+				SourcePath:      strings.ReplaceAll(path, "\\:", ":"),
 				DestinationPath: destinationPath,
 				Hash:            descriptor["hash"].(string),
 			}


### PR DESCRIPTION
* NMDC biosamples are no longer transferred -- only data objects
* File IDs for data objects are prefixed with their study IDs so we don't
  need the graph.
* Several errors are now properly propagated and can affect the success of a
  transfer.
* Test reports are less noisy (omitted the `-v` flag)