### PR TITLE
Converted `files/by-id` endpoint to use POST instead of GET.

### DIFF
--- a/integration/irods/integration_test.go
+++ b/integration/irods/integration_test.go
@@ -449,7 +449,7 @@ func TestTransfer(t *testing.T) {
 	file2path := "local-user/dts-" + transferIdString + "/file2.txt"
 	manifestPath := "local-user/dts-" + transferIdString + "/manifest.json"
 	md_req, err := json.Marshal(services.FileMetadataRequest{
-		Database: "db-foo",
+		Database: "db-bar",
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file1path, file2path, manifestPath},
 	})
@@ -537,7 +537,7 @@ func TestCancelTransfer(t *testing.T) {
 	file3path := "local-user/dts-" + transferIdString + "/dir1/file3.txt"
 	file4path := "local-user/dts-" + transferIdString + "/dir1/file4.txt"
 	md_req, err := json.Marshal(services.FileMetadataRequest{
-		Database: "db-foo",
+		Database: "db-bar",
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file3path, file4path},
 	})
@@ -723,7 +723,7 @@ func TestConcurrentTransfers(t *testing.T) {
 				filePaths = append(filePaths, "local-user/dts-"+transferIdString+"/"+file)
 			}
 			md_req, err := json.Marshal(services.FileMetadataRequest{
-				Database: "db-foo",
+				Database: result.info.Request.Destination,
 				Orcid:    "0000-0000-1234-0000",
 				FileIds:  filePaths,
 			})

--- a/integration/irods/integration_test.go
+++ b/integration/irods/integration_test.go
@@ -348,6 +348,7 @@ func TestDatabaseFetchMetadata(t *testing.T) {
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{"file1.txt", "dir2/file5.txt"},
 	})
+	assert.Nil(err, "failed to marshal file metadata request")
 	req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for database fetch metadata")
 	addAuthHeader(req)
@@ -452,6 +453,7 @@ func TestTransfer(t *testing.T) {
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file1path, file2path, manifestPath},
 	})
+	assert.Nil(err, "failed to marshal file metadata request")
 	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata")
 	addAuthHeader(req)
@@ -539,6 +541,7 @@ func TestCancelTransfer(t *testing.T) {
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file3path, file4path},
 	})
+	assert.Nil(err, "failed to marshal file metadata request")
 	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata after cancel")
 	addAuthHeader(req)
@@ -724,6 +727,7 @@ func TestConcurrentTransfers(t *testing.T) {
 				Orcid:    "0000-0000-1234-0000",
 				FileIds:  filePaths,
 			})
+			assert.Nil(err, "failed to marshal file metadata request")
 			req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 			assert.Nil(err, "failed to create request for destination database fetch metadata after processing")
 			addAuthHeader(req)

--- a/integration/irods/integration_test.go
+++ b/integration/irods/integration_test.go
@@ -343,7 +343,12 @@ func TestDatabaseFetchMetadata(t *testing.T) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
-	req, err := http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database=db-foo&ids=file1.txt,dir2/file5.txt", nil)
+	md_req, err := json.Marshal(services.FileMetadataRequest{
+		Database: "db-foo",
+		Orcid:    "0000-0000-1234-0000",
+		FileIds:  []string{"file1.txt", "dir2/file5.txt"},
+	})
+	req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for database fetch metadata")
 	addAuthHeader(req)
 
@@ -442,7 +447,12 @@ func TestTransfer(t *testing.T) {
 	file1path := "local-user/dts-" + transferIdString + "/file1.txt"
 	file2path := "local-user/dts-" + transferIdString + "/file2.txt"
 	manifestPath := "local-user/dts-" + transferIdString + "/manifest.json"
-	req, err = http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database=db-bar&ids="+file1path+","+file2path+","+manifestPath, nil)
+	md_req, err := json.Marshal(services.FileMetadataRequest{
+		Database: "db-foo",
+		Orcid:    "0000-0000-1234-0000",
+		FileIds:  []string{file1path, file2path, manifestPath},
+	})
+	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata")
 	addAuthHeader(req)
 
@@ -524,7 +534,12 @@ func TestCancelTransfer(t *testing.T) {
 	// make sure the files are not in the destination database
 	file3path := "local-user/dts-" + transferIdString + "/dir1/file3.txt"
 	file4path := "local-user/dts-" + transferIdString + "/dir1/file4.txt"
-	req, err = http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database=db-bar&ids="+file3path+","+file4path, nil)
+	md_req, err := json.Marshal(services.FileMetadataRequest{
+		Database: "db-foo",
+		Orcid:    "0000-0000-1234-0000",
+		FileIds:  []string{file3path, file4path},
+	})
+	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata after cancel")
 	addAuthHeader(req)
 
@@ -704,14 +719,12 @@ func TestConcurrentTransfers(t *testing.T) {
 			for _, file := range expectedFiles {
 				filePaths = append(filePaths, "local-user/dts-"+transferIdString+"/"+file)
 			}
-			idsParam := ""
-			for j, path := range filePaths {
-				if j > 0 {
-					idsParam += ","
-				}
-				idsParam += path
-			}
-			req, err := http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database="+result.info.Request.Destination+"&ids="+idsParam, nil)
+			md_req, err := json.Marshal(services.FileMetadataRequest{
+				Database: "db-foo",
+				Orcid:    "0000-0000-1234-0000",
+				FileIds:  filePaths,
+			})
+			req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 			assert.Nil(err, "failed to create request for destination database fetch metadata after processing")
 			addAuthHeader(req)
 

--- a/integration/minio/integration_test.go
+++ b/integration/minio/integration_test.go
@@ -348,6 +348,7 @@ func TestDatabaseFetchMetadata(t *testing.T) {
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{"file1.txt", "dir2/file5.txt"},
 	})
+	assert.Nil(err, "failed to marshal file metadata request")
 	req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for database fetch metadata")
 	addAuthHeader(req)
@@ -452,6 +453,7 @@ func TestTransfer(t *testing.T) {
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file1path, file2path, manifestPath},
 	})
+	assert.Nil(err, "failed to marshal file metadata request")
 	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata")
 	addAuthHeader(req)
@@ -539,6 +541,7 @@ func TestCancelTransfer(t *testing.T) {
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file3path, file4path},
 	})
+	assert.Nil(err, "failed to marshal file metadata request")
 	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata after cancel")
 	addAuthHeader(req)
@@ -725,6 +728,7 @@ func TestConcurrentTransfers(t *testing.T) {
 				Orcid:    "0000-0000-1234-0000",
 				FileIds:  filePaths,
 			})
+			assert.Nil(err, "failed to marshal file metadata request")
 			req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 			assert.Nil(err, "failed to create request for destination database fetch metadata after processing")
 			addAuthHeader(req)

--- a/integration/minio/integration_test.go
+++ b/integration/minio/integration_test.go
@@ -343,7 +343,12 @@ func TestDatabaseFetchMetadata(t *testing.T) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
-	req, err := http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database=db-foo&ids=file1.txt,dir2/file5.txt", nil)
+	md_req, err := json.Marshal(services.FileMetadataRequest{
+		Database: "db-foo",
+		Orcid:    "0000-0000-1234-0000",
+		FileIds:  []string{"file1.txt", "dir2/file5.txt"},
+	})
+	req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for database fetch metadata")
 	addAuthHeader(req)
 
@@ -442,7 +447,12 @@ func TestTransfer(t *testing.T) {
 	file1path := "local-user/dts-" + transferIdString + "/file1.txt"
 	file2path := "local-user/dts-" + transferIdString + "/file2.txt"
 	manifestPath := "local-user/dts-" + transferIdString + "/manifest.json"
-	req, err = http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database=db-bar&ids="+file1path+","+file2path+","+manifestPath, nil)
+	md_req, err := json.Marshal(services.FileMetadataRequest{
+		Database: "db-foo",
+		Orcid:    "0000-0000-1234-0000",
+		FileIds:  []string{file1path, file2path, manifestPath},
+	})
+	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata")
 	addAuthHeader(req)
 
@@ -524,7 +534,12 @@ func TestCancelTransfer(t *testing.T) {
 	// make sure the files are not in the destination database
 	file3path := "local-user/dts-" + transferIdString + "/dir1/file3.txt"
 	file4path := "local-user/dts-" + transferIdString + "/dir1/file4.txt"
-	req, err = http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database=db-bar&ids="+file3path+","+file4path, nil)
+	md_req, err := json.Marshal(services.FileMetadataRequest{
+		Database: "db-foo",
+		Orcid:    "0000-0000-1234-0000",
+		FileIds:  []string{file3path, file4path},
+	})
+	req, err = http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 	assert.Nil(err, "failed to create request for destination database fetch metadata after cancel")
 	addAuthHeader(req)
 
@@ -705,14 +720,12 @@ func TestConcurrentTransfers(t *testing.T) {
 			for _, file := range expectedFiles {
 				filePaths = append(filePaths, "local-user/dts-"+transferIdString+"/"+file)
 			}
-			idsParam := ""
-			for j, path := range filePaths {
-				if j > 0 {
-					idsParam += ","
-				}
-				idsParam += path
-			}
-			req, err := http.NewRequest("GET", testServiceURL+"/api/v1/files/by-id?database="+result.info.Request.Destination+"&ids="+idsParam, nil)
+			md_req, err := json.Marshal(services.FileMetadataRequest{
+				Database: "db-foo",
+				Orcid:    "0000-0000-1234-0000",
+				FileIds:  filePaths,
+			})
+			req, err := http.NewRequest("POST", testServiceURL+"/api/v1/files/by-id", bytes.NewBuffer(md_req))
 			assert.Nil(err, "failed to create request for destination database fetch metadata after processing")
 			addAuthHeader(req)
 

--- a/integration/minio/integration_test.go
+++ b/integration/minio/integration_test.go
@@ -449,7 +449,7 @@ func TestTransfer(t *testing.T) {
 	file2path := "local-user/dts-" + transferIdString + "/file2.txt"
 	manifestPath := "local-user/dts-" + transferIdString + "/manifest.json"
 	md_req, err := json.Marshal(services.FileMetadataRequest{
-		Database: "db-foo",
+		Database: "db-bar",
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file1path, file2path, manifestPath},
 	})
@@ -537,7 +537,7 @@ func TestCancelTransfer(t *testing.T) {
 	file3path := "local-user/dts-" + transferIdString + "/dir1/file3.txt"
 	file4path := "local-user/dts-" + transferIdString + "/dir1/file4.txt"
 	md_req, err := json.Marshal(services.FileMetadataRequest{
-		Database: "db-foo",
+		Database: "db-bar",
 		Orcid:    "0000-0000-1234-0000",
 		FileIds:  []string{file3path, file4path},
 	})
@@ -724,7 +724,7 @@ func TestConcurrentTransfers(t *testing.T) {
 				filePaths = append(filePaths, "local-user/dts-"+transferIdString+"/"+file)
 			}
 			md_req, err := json.Marshal(services.FileMetadataRequest{
-				Database: "db-foo",
+				Database: result.info.Request.Destination,
 				Orcid:    "0000-0000-1234-0000",
 				FileIds:  filePaths,
 			})

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -69,7 +69,7 @@ func NewDTSPrototype() (TransferService, error) {
 	huma.Get(api, "/api/v1/databases/{db}/search-parameters", service.getDatabaseSearchParameters)
 	huma.Get(api, "/api/v1/files", service.searchDatabase)
 	huma.Post(api, "/api/v1/files", service.searchDatabaseWithSpecificParams)
-	huma.Get(api, "/api/v1/files/by-id", service.fetchFileMetadata)
+	huma.Post(api, "/api/v1/files/by-id", service.fetchFileMetadata)
 	huma.Post(api, "/api/v1/transfers", service.createTransfer)
 	huma.Get(api, "/api/v1/transfers/{id}", service.getTransferStatus)
 	huma.Delete(api, "/api/v1/transfers/{id}", service.deleteTransfer)
@@ -561,30 +561,27 @@ type FileMetadataOutput struct {
 // fetches file metadata given a list of file identifiers
 func (service *prototype) fetchFileMetadata(ctx context.Context,
 	input *struct {
-		Authorization string `header:"authorization" doc:"Authorization header with encoded access token"`
-		Database      string `json:"database" query:"database" example:"jdp" doc:"The ID of the database for which file metadata is fetched"`
-		Orcid         string `json:"orcid" query:"orcid" example:"1234-5678-9101-112X" doc:"The ORCID of the user requesting metadata"`
-		Ids           string `json:"ids" query:"ids" example:"JDP:6101cc0f2b1f2eeea564c978" doc:"A comma-separated list of file IDs"`
-		Offset        int    `json:"offset" query:"offset" example:"100" doc:"Metadata records begin at the given offset"`
-		Limit         int    `json:"limit" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
+		Authorization string              `header:"authorization" doc:"Authorization header with encoded access token"`
+		Body          FileMetadataRequest `doc:"Contains all file metadata request parameters"`
 	}) (*FileMetadataOutput, error) {
 
 	user, err := authorize(input.Authorization)
 	if err != nil {
 		return nil, err
 	}
+	print(input.Body.Orcid)
 
 	// is the database valid?
-	_, ok := config.Databases[input.Database]
+	_, ok := config.Databases[input.Body.Database]
 	if !ok {
-		return nil, huma.Error404NotFound(fmt.Sprintf("database %s not found", input.Database))
+		return nil, huma.Error404NotFound(fmt.Sprintf("database %s not found", input.Body.Database))
 	}
 
 	// have we been given any IDs?
-	if strings.TrimSpace(input.Ids) == "" {
+	if strings.TrimSpace(input.Body.Ids) == "" {
 		return nil, huma.Error400BadRequest("No file IDs were provided!")
 	}
-	ids := strings.Split(input.Ids, ",")
+	ids := strings.Split(input.Body.Ids, ",")
 
 	// have we been given duplicate IDs?
 	duplicates := duplicateFileIds(ids)
@@ -594,14 +591,14 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 	}
 
 	slog.Info(fmt.Sprintf("Fetching file metadata for %d files in database %s...",
-		len(ids), input.Database))
-	db, err := databases.NewDatabase(input.Database)
+		len(ids), input.Body.Database))
+	db, err := databases.NewDatabase(input.Body.Database)
 	if err != nil {
 		return nil, databaseError(err)
 	}
 
 	// FIXME: for now, if a user ORCID is not specified, use the authorized user's ORCID
-	orcid := input.Orcid
+	orcid := input.Body.Orcid
 	if orcid == "" {
 		orcid = user.Orcid
 	}
@@ -622,7 +619,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 	}
 	return &FileMetadataOutput{
 		Body: FileMetadataResponse{
-			Database:    input.Database,
+			Database:    input.Body.Database,
 			Descriptors: descriptors,
 		},
 	}, nil

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -563,6 +563,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 	input *struct {
 		Authorization string              `header:"authorization" doc:"Authorization header with encoded access token"`
 		Body          FileMetadataRequest `doc:"Contains all file metadata request parameters"`
+		ContentType   string              `header:"Content-Type" doc:"Content-Type header (must be application/json)"`
 	}) (*FileMetadataOutput, error) {
 
 	user, err := authorize(input.Authorization)

--- a/services/prototype.go
+++ b/services/prototype.go
@@ -579,20 +579,19 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 	}
 
 	// have we been given any IDs?
-	if strings.TrimSpace(input.Body.Ids) == "" {
+	if len(input.Body.FileIds) == 0 {
 		return nil, huma.Error400BadRequest("No file IDs were provided!")
 	}
-	ids := strings.Split(input.Body.Ids, ",")
 
 	// have we been given duplicate IDs?
-	duplicates := duplicateFileIds(ids)
+	duplicates := duplicateFileIds(input.Body.FileIds)
 	if duplicates != nil {
 		return nil, huma.Error400BadRequest(fmt.Sprintf("The following requested file IDs have duplicates, which are forbidden: %s",
 			strings.Join(duplicates, ", ")))
 	}
 
 	slog.Info(fmt.Sprintf("Fetching file metadata for %d files in database %s...",
-		len(ids), input.Body.Database))
+		len(input.Body.FileIds), input.Body.Database))
 	db, err := databases.NewDatabase(input.Body.Database)
 	if err != nil {
 		return nil, databaseError(err)
@@ -604,7 +603,7 @@ func (service *prototype) fetchFileMetadata(ctx context.Context,
 		orcid = user.Orcid
 	}
 
-	descriptors, err := db.Descriptors(orcid, ids)
+	descriptors, err := db.Descriptors(orcid, input.Body.FileIds)
 	if err != nil {
 		slog.Error(err.Error())
 		return nil, huma.Error500InternalServerError(err.Error())

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -564,13 +564,27 @@ func TestFetchJdpMetadata(t *testing.T) {
 	}
 
 	// try omitting file IDs
-	resp, err := get(baseUrl + apiPrefix + "files/by-id?database=jdp")
+	orcid := dtsKbaseTestOrcid
+	payload, err := json.Marshal(FileMetadataRequest{
+		Database: "jdp",
+		Orcid:    orcid,
+	})
+	assert.Nil(err)
+	resp, err := post(baseUrl+apiPrefix+"files/by-id", bytes.NewReader(payload))
 	assert.Nil(err)
 	assert.Equal(http.StatusBadRequest, resp.StatusCode)
 
 	// now let's fetch 3 records
-	resp, err = get(baseUrl + apiPrefix +
-		"files/by-id?database=jdp&ids=JDP:6101cc0f2b1f2eeea564c978,JDP:613a7baa72d3a08c9a54b32d,JDP:61412246cc4ff44f36c8913d")
+	payload, err = json.Marshal(FileMetadataRequest{
+		Database: "jdp",
+		Orcid:    orcid,
+		FileIds: []string{
+			"JDP:6101cc0f2b1f2eeea564c978",
+			"JDP:613a7baa72d3a08c9a54b32d",
+			"JDP:61412246cc4ff44f36c8913d",
+		},
+	})
+	resp, err = post(baseUrl+apiPrefix+"files/by-id", bytes.NewReader(payload))
 	assert.Nil(err)
 
 	respBody, err := io.ReadAll(resp.Body)

--- a/services/prototype_test.go
+++ b/services/prototype_test.go
@@ -584,6 +584,7 @@ func TestFetchJdpMetadata(t *testing.T) {
 			"JDP:61412246cc4ff44f36c8913d",
 		},
 	})
+	assert.Nil(err)
 	resp, err = post(baseUrl+apiPrefix+"files/by-id", bytes.NewReader(payload))
 	assert.Nil(err)
 

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -34,11 +34,18 @@ type SearchResultsResponse struct {
 	Descriptors []map[string]any `json:"resources" doc:"an array of validated Frictionless descriptors"`
 }
 
-// a response for a file metadata query (GET)
+// a request for file metadata (POST)
+type FileMetadataRequest struct {
+	Database string `json:"database" query:"database" example:"jdp" doc:"The ID of the database for which file metadata is fetched"`
+	Orcid    string `json:"orcid" query:"orcid" example:"1234-5678-9101-112X" doc:"The ORCID of the user requesting metadata"`
+	Ids      string `json:"ids" query:"ids" example:"JDP:6101cc0f2b1f2eeea564c978" doc:"A comma-separated list of file IDs"`
+	Offset   int    `json:"offset" query:"offset" example:"100" doc:"Metadata records begin at the given offset"`
+	Limit    int    `json:"limit" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
+}
+
+// a response for a file metadata query (POST)
 type FileMetadataResponse struct {
-	// name of organization database
-	Database string `json:"database" example:"jdp" doc:"the database searched"`
-	// resources corresponding to given file IDs
+	Database    string           `json:"database" example:"jdp" doc:"the database searched"`
 	Descriptors []map[string]any `json:"resources" doc:"an array of validated Frictionless descriptors"`
 }
 

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -36,11 +36,11 @@ type SearchResultsResponse struct {
 
 // a request for file metadata (POST)
 type FileMetadataRequest struct {
-	Database string `json:"database" query:"database" example:"jdp" doc:"The ID of the database for which file metadata is fetched"`
-	Orcid    string `json:"orcid" query:"orcid" example:"1234-5678-9101-112X" doc:"The ORCID of the user requesting metadata"`
-	Ids      string `json:"ids" query:"ids" example:"JDP:6101cc0f2b1f2eeea564c978" doc:"A comma-separated list of file IDs"`
-	Offset   int    `json:"offset,omitempty" query:"offset" example:"100" doc:"Metadata records begin at the given offset"`
-	Limit    int    `json:"limit,omitempty" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
+	Database string   `json:"database" query:"database" example:"jdp" doc:"The ID of the database for which file metadata is fetched"`
+	Orcid    string   `json:"orcid" query:"orcid" example:"1234-5678-9101-112X" doc:"The ORCID of the user requesting metadata"`
+	FileIds  []string `json:"ids" query:"ids" example:"[JDP:6101cc0f2b1f2eeea564c978]" doc:"An array of file IDs"`
+	Offset   int      `json:"offset,omitempty" query:"offset" example:"100" doc:"Metadata records begin at the given offset"`
+	Limit    int      `json:"limit,omitempty" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
 }
 
 // a response for a file metadata query (POST)

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -39,8 +39,8 @@ type FileMetadataRequest struct {
 	Database string `json:"database" query:"database" example:"jdp" doc:"The ID of the database for which file metadata is fetched"`
 	Orcid    string `json:"orcid" query:"orcid" example:"1234-5678-9101-112X" doc:"The ORCID of the user requesting metadata"`
 	Ids      string `json:"ids" query:"ids" example:"JDP:6101cc0f2b1f2eeea564c978" doc:"A comma-separated list of file IDs"`
-	Offset   int    `json:"offset" query:"offset" example:"100" doc:"Metadata records begin at the given offset"`
-	Limit    int    `json:"limit" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
+	Offset   int    `json:"offset,omitempty" query:"offset" example:"100" doc:"Metadata records begin at the given offset"`
+	Limit    int    `json:"limit,omitempty" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
 }
 
 // a response for a file metadata query (POST)

--- a/services/transfer_service.go
+++ b/services/transfer_service.go
@@ -36,11 +36,11 @@ type SearchResultsResponse struct {
 
 // a request for file metadata (POST)
 type FileMetadataRequest struct {
-	Database string   `json:"database" query:"database" example:"jdp" doc:"The ID of the database for which file metadata is fetched"`
-	Orcid    string   `json:"orcid" query:"orcid" example:"1234-5678-9101-112X" doc:"The ORCID of the user requesting metadata"`
-	FileIds  []string `json:"ids" query:"ids" example:"[JDP:6101cc0f2b1f2eeea564c978]" doc:"An array of file IDs"`
-	Offset   int      `json:"offset,omitempty" query:"offset" example:"100" doc:"Metadata records begin at the given offset"`
-	Limit    int      `json:"limit,omitempty" query:"limit" example:"50" doc:"Limits the number of metadata records returned"`
+	Database string   `json:"database" example:"jdp" doc:"The ID of the database for which file metadata is fetched"`
+	Orcid    string   `json:"orcid" example:"1234-5678-9101-112X" doc:"The ORCID of the user requesting metadata"`
+	FileIds  []string `json:"file_ids" example:"[\"JDP:6101cc0f2b1f2eeea564c978\"]" doc:"An array of file IDs"`
+	Offset   int      `json:"offset,omitempty" example:"100" doc:"Metadata records begin at the given offset"`
+	Limit    int      `json:"limit,omitempty" example:"50" doc:"Limits the number of metadata records returned"`
 }
 
 // a response for a file metadata query (POST)

--- a/services/version.go
+++ b/services/version.go
@@ -6,8 +6,8 @@ import (
 
 // Version numbers
 var majorVersion = 0
-var minorVersion = 11
-var patchVersion = 3
+var minorVersion = 12
+var patchVersion = 0
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)


### PR DESCRIPTION
This change supports the generation of large manifests for payloads without actually performing transfers, which is useful for debugging filesystem-related (and other) issues.