### PR TITLE
Pointing the iRODS dockerfile at a valid base image.

### DIFF
--- a/etc/irods/Dockerfile.irods_provider
+++ b/etc/irods/Dockerfile.irods_provider
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:noble
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This fixes the broken `irods-integration-tests` workflow.