### PR TITLE
Added CloudFlare ray IDs to error messages for challenges.

### DIFF
--- a/auth/kbase_auth_server.go
+++ b/auth/kbase_auth_server.go
@@ -166,9 +166,19 @@ func kbaseAuthError(response *http.Response) error {
 		var result kbaseAuthErrorResponse
 		mErr = json.Unmarshal(body, &result)
 		if mErr != nil {
-			if strings.Contains(string(body), "cloudflare") {
-				err = fmt.Errorf("KBase Auth error (%d): %s", response.StatusCode,
-					"Authenticator is protected by a Cloudflare challenge")
+			bodyStr := string(body)
+			if strings.Contains(bodyStr, "cloudflare") {
+				// parse the ray ID for diagnostics
+				rayId := "unknown"
+				begin := strings.Index(bodyStr, "cRay: '")
+				if begin != -1 {
+					end := begin + strings.Index(bodyStr[begin:], "',")
+					if end != -1 {
+						rayId = bodyStr[begin+7 : end]
+					}
+				}
+				err = fmt.Errorf("KBase Auth error (%d): Authenticator is protected by a Cloudflare challenge (ray ID = %s)",
+					response.StatusCode, rayId)
 			}
 		} else {
 			if len(result.Message) > 0 {

--- a/services/version.go
+++ b/services/version.go
@@ -7,7 +7,7 @@ import (
 // Version numbers
 var majorVersion = 0
 var minorVersion = 13
-var patchVersion = 2
+var patchVersion = 3
 
 // Version string
 var version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, patchVersion)


### PR DESCRIPTION
These ray IDs are useful for managing the CloudFlare bot shield protecting the KBase auth2 server, which seems to be preventing authentication requests by the DTS originating from the IMG -> KBase push service.