### PR TITLE
Re-enabling KBase Auth server tests.

### DIFF
--- a/auth/kbase_auth_server_test.go
+++ b/auth/kbase_auth_server_test.go
@@ -136,7 +136,6 @@ func getKbaseToken() (string, bool) {
 // tests whether a proxy for the KBase authentication server can be
 // constructed
 func TestNewKBaseAuthServer(t *testing.T) {
-	t.Skip("Skipping KBase auth2 server test (access denied by Cloudflare bot storm security)")
 	assert := assert.New(t)
 
 	devToken, ok := getKbaseToken()
@@ -159,7 +158,6 @@ func TestNewKBaseAuthServer(t *testing.T) {
 // tests whether an invalid KBase token prevents a proxy for the auth server
 // from being constructed
 func TestInvalidToken(t *testing.T) {
-	t.Skip("Skipping KBase auth2 server test (access denied by Cloudflare bot storm security)")
 	assert := assert.New(t)
 
 	_, ok := getKbaseToken()
@@ -182,7 +180,6 @@ func TestInvalidToken(t *testing.T) {
 
 // tests that the proxy handles missing identifiers correctly
 func TestNoIdentifiers(t *testing.T) {
-	t.Skip("Skipping KBase auth2 server test (access denied by Cloudflare bot storm security)")
 	assert := assert.New(t)
 
 	_, ok := getKbaseToken()
@@ -201,7 +198,6 @@ func TestNoIdentifiers(t *testing.T) {
 
 // tests that the proxy handles missing OrcID identifiers correctly
 func TestNoOrcID(t *testing.T) {
-	t.Skip("Skipping KBase auth2 server test (access denied by Cloudflare bot storm security)")
 	assert := assert.New(t)
 
 	_, ok := getKbaseToken()
@@ -221,7 +217,6 @@ func TestNoOrcID(t *testing.T) {
 // tests whether the authentication server can return information for the
 // client (the user associated with the specified developer token)
 func TestClient(t *testing.T) {
-	t.Skip("Skipping KBase auth2 server test (access denied by Cloudflare bot storm security)")
 	assert := assert.New(t)
 
 	devToken, ok := getKbaseToken()


### PR DESCRIPTION
We talked with KBase's security folks about making some adjustments to CloudFlare's bot screen on the KBase Auth2 server. The unit tests that were failing should pass now.